### PR TITLE
Fix: Burn functions not decreasing totalSupply

### DIFF
--- a/src/ERC20/ERC20/ERC20Facet.sol
+++ b/src/ERC20/ERC20/ERC20Facet.sol
@@ -215,6 +215,7 @@ contract ERC20Facet {
         }
         unchecked {
             s.balanceOf[msg.sender] = balance - _value;
+            s.totalSupply -= _value;
         }
         emit Transfer(msg.sender, address(0), _value);
     }
@@ -238,6 +239,7 @@ contract ERC20Facet {
         unchecked {
             s.allowances[_account][msg.sender] = currentAllowance - _value;
             s.balanceOf[_account] = balance - _value;
+            s.totalSupply -= _value;
         }
         emit Transfer(msg.sender, address(0), _value);
     }


### PR DESCRIPTION
Fixes #24 

The burn() and burnFrom() functions were not decreasing the totalSupply, causing the total supply to remain artificially inflated after tokens were burned.

This fix adds totalSupply decrement to both functions within their unchecked blocks, ensuring totalSupply accurately reflects the actual token supply.