### PR TITLE
Fix: Incorrect event emission in burnFrom()

### DIFF
--- a/src/ERC20/ERC20/ERC20Facet.sol
+++ b/src/ERC20/ERC20/ERC20Facet.sol
@@ -239,7 +239,7 @@ contract ERC20Facet {
             s.allowances[_account][msg.sender] = currentAllowance - _value;
             s.balanceOf[_account] = balance - _value;
         }
-        emit Transfer(msg.sender, address(0), _value);
+        emit Transfer(_account, address(0), _value);
     }
 
     // EIP-2612 Permit Extension


### PR DESCRIPTION
Fixes #25 

The burnFrom() function was emitting a Transfer event with msg.sender as the 'from' address instead of _account (the address whose tokens are being burned).

This caused event logs to incorrectly report who the tokens were burned from, breaking compatibility with wallets and indexers that rely on Transfer events.