### PR TITLE
Fix: Integer overflow vulnerability in recipient balance updates

### DIFF
--- a/src/ERC20/ERC20/ERC20Facet.sol
+++ b/src/ERC20/ERC20/ERC20Facet.sol
@@ -166,8 +166,8 @@ contract ERC20Facet {
         }
         unchecked {
             s.balanceOf[msg.sender] = fromBalance - _value;
-            s.balanceOf[_to] += _value;
         }
+        s.balanceOf[_to] += _value;
         emit Transfer(msg.sender, _to, _value);
     }
 
@@ -197,8 +197,8 @@ contract ERC20Facet {
         unchecked {
             s.allowances[_from][msg.sender] = currentAllowance - _value;
             s.balanceOf[_from] = fromBalance - _value;
-            s.balanceOf[_to] += _value;
         }
+        s.balanceOf[_to] += _value;
         emit Transfer(_from, _to, _value);
     }
 

--- a/src/ERC20/ERC20/libraries/LibERC20.sol
+++ b/src/ERC20/ERC20/libraries/LibERC20.sol
@@ -71,10 +71,8 @@ library LibERC20 {
         if (_account == address(0)) {
             revert ERC20InvalidReceiver(address(0));
         }
-        unchecked {
-            s.totalSupply += _value;
-            s.balanceOf[_account] += _value;
-        }
+        s.totalSupply += _value;
+        s.balanceOf[_account] += _value;
         emit Transfer(address(0), _account, _value);
     }
 
@@ -122,8 +120,8 @@ library LibERC20 {
         unchecked {
             s.allowances[_from][msg.sender] = currentAllowance - _value;
             s.balanceOf[_from] = fromBalance - _value;
-            s.balanceOf[_to] += _value;
         }
+        s.balanceOf[_to] += _value;
         emit Transfer(_from, _to, _value);
     }
 
@@ -142,8 +140,8 @@ library LibERC20 {
         }
         unchecked {
             s.balanceOf[msg.sender] = fromBalance - _value;
-            s.balanceOf[_to] += _value;
         }
+        s.balanceOf[_to] += _value;
         emit Transfer(msg.sender, _to, _value);
     }
 


### PR DESCRIPTION
Fixes #26 

Recipient balance additions were inside unchecked blocks, allowing potential overflow attacks where an attacker could overflow a recipient's balance to zero, effectively stealing tokens.

This fix moves all recipient balance additions outside unchecked blocks in both ERC20Facet and LibERC20, enabling Solidity's built-in overflow protection.

Affected functions:
- ERC20Facet: transfer(), transferFrom()
- LibERC20: mint(), transfer(), transferFrom()