### PR TITLE
Fix: Missing zero address validation in permit()

### DIFF
--- a/src/ERC20/ERC20/ERC20Facet.sol
+++ b/src/ERC20/ERC20/ERC20Facet.sol
@@ -291,6 +291,9 @@ contract ERC20Facet {
         bytes32 _r,
         bytes32 _s
     ) external {
+        if (_spender == address(0)) {
+            revert ERC20InvalidSpender(address(0));
+        }
         if (block.timestamp > _deadline) {
             revert ERC2612InvalidSignature(_owner, _spender, _value, _deadline, _v, _r, _s);
         }


### PR DESCRIPTION
Fixes #28 

The permit() function was missing zero address validation for the spender parameter, allowing gasless approvals to the zero address which violates the ERC-20 standard and EIP-2612 best practices.

This fix adds spender validation at the beginning of permit(), ensuring consistency with the approve() function and preventing invalid permits.