### PR TITLE
Remove unused ERC20InvalidApprover error

### DIFF
--- a/src/ERC20/ERC20/ERC20Facet.sol
+++ b/src/ERC20/ERC20/ERC20Facet.sol
@@ -22,10 +22,6 @@ contract ERC20Facet {
     /// @param _needed Amount required to complete the operation.
     error ERC20InsufficientAllowance(address _spender, uint256 _allowance, uint256 _needed);
 
-    /// @notice Thrown when the approver address is invalid (e.g., zero address).
-    /// @param _approver Invalid approver address.
-    error ERC20InvalidApprover(address _approver);
-
     /// @notice Thrown when the spender address is invalid (e.g., zero address).
     /// @param _spender Invalid spender address.
     error ERC20InvalidSpender(address _spender);


### PR DESCRIPTION
Fixes #47 

The ERC20InvalidApprover error was declared but never used anywhere in the codebase. Analysis shows it's not needed because:

- approve() uses msg.sender as approver, which can never be address(0)
- permit() signature verification would fail for address(0) anyway

This error appears to have been included for ERC-6093 compliance but serves no practical purpose in the current implementation.