### PR TITLE
ERC173 - emit OwnershipTransferred after func logic

### DIFF
--- a/src/ERC173/ERC173.sol
+++ b/src/ERC173/ERC173.sol
@@ -38,7 +38,7 @@ contract ERC173Facet {
     function transferOwnership(address _newOwner) external {
         ERC173Storage storage s = getStorage();
         if (msg.sender != s.owner) revert OwnableUnauthorizedAccount();
-        emit OwnershipTransferred(s.owner, _newOwner);
         s.owner = _newOwner;
+        emit OwnershipTransferred(s.owner, _newOwner);
     }
 }

--- a/src/ERC173/libraries/LibERC173.sol
+++ b/src/ERC173/libraries/LibERC173.sol
@@ -38,7 +38,7 @@ library LibERC173 {
     function transferOwnership(address _newOwner) internal {
         ERC173Storage storage s = getStorage();
         if (s.owner == address(0)) revert OwnableAlreadyRenounced();
-        emit OwnershipTransferred(s.owner, _newOwner);
         s.owner = _newOwner;
+        emit OwnershipTransferred(s.owner, _newOwner);
     }
 }


### PR DESCRIPTION
move the emit at the end of the function logic to avoid emitting before a potential func revert

See issue #51 