### PR TITLE
Add/explicit renounce ownership func

### DIFF
--- a/src/ERC173/ERC173.sol
+++ b/src/ERC173/ERC173.sol
@@ -43,4 +43,17 @@ contract ERC173Facet {
 
         emit OwnershipTransferred(previousOwner, _newOwner);
     }
+
+    /// @notice Renounce ownership of the contract
+    /// @dev Sets the owner to address(0), disabling all functions restricted to the owner.
+    function renounceOwnership() external {
+        ERC173Storage storage s = getStorage();
+        if (msg.sender != s.owner) revert OwnableUnauthorizedAccount();
+
+        address previousOwner = s.owner;
+        s.owner = address(0);
+
+        emit OwnershipTransferred(previousOwner, address(0));
+    }
+
 }

--- a/src/ERC173/libraries/LibERC173.sol
+++ b/src/ERC173/libraries/LibERC173.sol
@@ -43,4 +43,16 @@ library LibERC173 {
 
         emit OwnershipTransferred(previousOwner, _newOwner);
     }
+
+    /// @notice Renounce ownership of the contract
+    /// @dev Sets the owner to address(0), disabling all functions restricted to the owner
+    function renounceOwnership() internal {
+        ERC173Storage storage s = getStorage();
+        if (s.owner == address(0)) revert OwnableAlreadyRenounced();
+
+        address previousOwner = s.owner;
+        s.owner = address(0);
+
+        emit OwnershipTransferred(previousOwner, address(0));
+    }
 }


### PR DESCRIPTION
###Reference:
This implementation mirrors OpenZeppelin’s Ownable.renounceOwnership() function for clarity and interoperability.

Source: [OpenZeppelin Contracts v5.0.0 – Ownable.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol)