### PR TITLE
Change _approved to _to for approve function and event

### DIFF
--- a/src/ERC721/ERC721/ERC721Facet.sol
+++ b/src/ERC721/ERC721/ERC721Facet.sol
@@ -50,7 +50,7 @@ contract ERC721Facet {
     event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
 
     /// @notice Emitted when the approved address for an NFT is changed or reaffirmed.
-    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+    event Approval(address indexed _owner, address indexed _to, uint256 indexed _tokenId);
 
     /// @notice Emitted when an operator is enabled or disabled for an owner.
     event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
@@ -131,19 +131,19 @@ contract ERC721Facet {
     }
 
     /// @notice Approves another address to transfer the given token ID.
-    /// @param _approved The address to be approved.
+    /// @param _to The address to be approved.
     /// @param _tokenId The token ID to approve.
-    function approve(address _approved, uint256 _tokenId) external {
+    function approve(address _to, uint256 _tokenId) external {
         ERC721Storage storage s = getStorage();
         address owner = s.ownerOf[_tokenId];
         if (owner == address(0)) {
             revert ERC721NonexistentToken(_tokenId);
         }
         if (msg.sender != owner && !s.isApprovedForAll[owner][msg.sender]) {
-            revert ERC721InvalidApprover(_approved);
+            revert ERC721InvalidApprover(msg.sender);
         }
-        s.approved[_tokenId] = _approved;
-        emit Approval(owner, _approved, _tokenId);
+        s.approved[_tokenId] = _to;
+        emit Approval(owner, _to, _tokenId);
     }
 
     /// @notice Approves or revokes permission for an operator to manage all caller's assets.

--- a/src/ERC721/ERC721Enumerable/ERC721EnumerableFacet.sol
+++ b/src/ERC721/ERC721Enumerable/ERC721EnumerableFacet.sol
@@ -42,7 +42,7 @@ contract ERC721EnumerableFacet {
     /// @notice Emitted when a token is transferred between addresses.
     event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
     /// @notice Emitted when a token is approved for transfer by another address.
-    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+    event Approval(address indexed _owner, address indexed _to, uint256 indexed _tokenId);
     /// @notice Emitted when an operator is approved or revoked for all tokens of an owner.
     event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
 
@@ -142,19 +142,19 @@ contract ERC721EnumerableFacet {
     }
 
     /// @notice Approves another address to transfer a specific token ID.
-    /// @param _approved The address being approved.
+    /// @param _to The address being approved.
     /// @param _tokenId The token ID to approve.
-    function approve(address _approved, uint256 _tokenId) external {
+    function approve(address _to, uint256 _tokenId) external {
         ERC721EnumerableStorage storage s = getStorage();
         address owner = s.ownerOf[_tokenId];
         if (owner == address(0)) {
             revert ERC721NonexistentToken(_tokenId);
         }
         if (msg.sender != owner && !s.isApprovedForAll[owner][msg.sender]) {
-            revert ERC721InvalidApprover(_approved);
+            revert ERC721InvalidApprover(msg.sender);
         }
-        s.approved[_tokenId] = _approved;
-        emit Approval(owner, _approved, _tokenId);
+        s.approved[_tokenId] = _to;
+        emit Approval(owner, _to, _tokenId);
     }
 
     /// @notice Approves or revokes an operator to manage all tokens of the caller.


### PR DESCRIPTION
for readability, `_approved` param is used for boolean only instead with `address`

I also change the emit of `ERC721InvalidApprover(_approved)` to `ERC721InvalidApprover(msg.sender)`, because changing it into `ERC721InvalidApprover(_to)` seems incorrect

should resolve #67 and #68 