### PR TITLE
Provide an organized and consistent way to credit contributors for th…

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,13 @@
+{
+  "files": ["README.md"],
+  "imageSize": 100,
+  "commit": false,
+  "contributors": [],
+  "contributorsPerLine": 7,
+  "projectName": "Compose",
+  "projectOwner": "mudgen",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "skipCi": true,
+  "commitConvention": "none"
+}

--- a/README.md
+++ b/README.md
@@ -122,3 +122,26 @@ This project is licensed under the MIT License. See the [LICENSE.md](LICENSE.md)
 
 **-Nick**
 
+## Adding yourself as a contributor
+
+If you've contributed to this project, you can easily add yourself to the contributors list by commenting on any issue or pull request with: `@all-contributors please add <your-github-username> for <contribution-type>`
+
+For example: `@all-contributors please add @mudgen for code, doc, business, and ideas`
+
+For a full list of contribution types, check out the [emoji key](https://allcontributors.org/docs/en/emoji-key).
+
+
+## Contributors ✨
+
+Thanks goes to these wonderful people 1:
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification.
+Contributions of any kind welcome!


### PR DESCRIPTION
Issue #87 – Provide an organized and consistent way to credit contributors for their contributions

With this setup, contributors whose pull requests are merged can easily be credited in the .all-contributorsrc file, and their avatars will automatically appear in the project’s README.md file.

I’ve tested this on a personal project, and it works perfectly.
You can see the attached image for reference.

<img width="1510" height="802" alt="Screenshot 2025-10-22 at 19 47 53" src="https://github.com/user-attachments/assets/e697779b-ef6d-4c7f-a147-1b392ffe32d1" />


To add contributors manually via comments, use the following commands in your PR or issue thread:

@all-contributors please add @<username> for <contributions>
@all-contributors please add @<username> for <contributions>

Replace <username> with the contributor’s GitHub handle and <contributions> with their contribution types (e.g., code, doc, design, infra, test).

Once the command is posted, the All Contributors Bot will automatically create a commit updating both the .all-contributorsrc configuration file and the project README.md with the contributor’s avatar and credit.