### PR TITLE
Fix natspec for clarity about two-step transfer ownership

### DIFF
--- a/src/access/OwnerTwoSteps/LibOwnerTwoSteps.sol
+++ b/src/access/OwnerTwoSteps/LibOwnerTwoSteps.sol
@@ -48,7 +48,7 @@ library LibOwnerTwoSteps {
     }
 
     /// @notice Initiates a two-step ownership transfer.
-    /// @param _newOwner The address of the new owner (set to `address(0)` to renounce).
+    /// @param _newOwner The address of the new owner of the contract
     function transferOwnership(address _newOwner) internal {
         OwnerTwoStepsStorage storage s = getStorage();
         s.pendingOwner = _newOwner;

--- a/src/access/OwnerTwoSteps/OwnerTwoSteps.sol
+++ b/src/access/OwnerTwoSteps/OwnerTwoSteps.sol
@@ -42,7 +42,6 @@ contract OwnerTwoStepsFacet {
     }
 
     /// @notice Set the address of the new owner of the contract
-    /// @dev Set _newOwner to address(0) to renounce any ownership.
     /// @param _newOwner The address of the new owner of the contract
     function transferOwnership(address _newOwner) external {
         OwnerTwoStepsStorage storage s = getStorage();


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of your changes -->

## Changes Made

<!-- List the main changes you made -->
two step ownership contract: removing the natspec about address(0) as param for `transferOwnership`

## Checklist

Before submitting this PR, please ensure:

- [x] **Code follows the Solidity feature ban** - No inheritance, constructors, modifiers, public/private variables, external library functions, `using for` directives, or `selfdestruct`

- [x] **Code follows Design Principles** - Readable, uses diamond storage, favors composition over inheritance

- [x] **Code matches the codebase style** - Consistent formatting, documentation, and patterns (e.g. ERC20Facet.sol)

- [ ] **Code is formatted with `forge fmt`**

- [ ] **Tests are included** - All new functionality has comprehensive tests

- [ ] **All tests pass** - Run `forge test` and ensure everything works

- [ ] **Documentation updated** - If applicable, update relevant documentation

Make sure to follow the [CONTRIBUTING.md](https://github.com/Perfect-Abstractions/Compose/blob/main/CONTRIBUTING.md) guidelines.

## Additional Notes

<!-- Any additional information, concerns, or questions for reviewers -->
