### PR TITLE
refactor: reorganize ERC20 tests into token directory structure

### DIFF
--- a/test/token/ERC20/ERC20/ERC20Facet.t.sol
+++ b/test/token/ERC20/ERC20/ERC20Facet.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.30;
 
 import {Test} from "forge-std/Test.sol";
-import {ERC20Facet} from "../../src/token/ERC20/ERC20/ERC20Facet.sol";
+import {ERC20Facet} from "../../../../src/token/ERC20/ERC20/ERC20Facet.sol";
 import {ERC20FacetHarness} from "./harnesses/ERC20FacetHarness.sol";
 
 contract ERC20FacetTest is Test {

--- a/test/token/ERC20/ERC20/LibERC20.t.sol
+++ b/test/token/ERC20/ERC20/LibERC20.t.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.30;
 
 import {Test} from "forge-std/Test.sol";
 import {LibERC20Harness} from "./harnesses/LibERC20Harness.sol";
-import {LibERC20} from "../../src/token/ERC20/ERC20/LibERC20.sol";
+import {LibERC20} from "../../../../src/token/ERC20/ERC20/LibERC20.sol";
 
 contract LibERC20Test is Test {
     LibERC20Harness public harness;

--- a/test/token/ERC20/ERC20/harnesses/ERC20FacetHarness.sol
+++ b/test/token/ERC20/ERC20/harnesses/ERC20FacetHarness.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.30;
 
-import {ERC20Facet} from "../../../src/token/ERC20/ERC20/ERC20Facet.sol";
+import {ERC20Facet} from "../../../../../src/token/ERC20/ERC20/ERC20Facet.sol";
 
 /// @title ERC20FacetHarness
 /// @notice Test harness for ERC20Facet that adds initialization and minting for testing

--- a/test/token/ERC20/ERC20/harnesses/LibERC20Harness.sol
+++ b/test/token/ERC20/ERC20/harnesses/LibERC20Harness.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.30;
 
-import {LibERC20} from "../../../src/token/ERC20/ERC20/LibERC20.sol";
+import {LibERC20} from "../../../../../src/token/ERC20/ERC20/LibERC20.sol";
 
 /// @title LibERC20Harness
 /// @notice Test harness that exposes LibERC20's internal functions as external


### PR DESCRIPTION
Fixes #128 

Moved ERC20 test files from test/ERC20/ to test/token/ERC20/ERC20/ to follow a more structured organization that groups token-related tests together.

Files moved:
- test/ERC20/ERC20Facet.t.sol -> test/token/ERC20/ERC20/ERC20Facet.t.sol
- test/ERC20/LibERC20.t.sol -> test/token/ERC20/ERC20/LibERC20.t.sol
- test/ERC20/harnesses/ERC20FacetHarness.sol -> test/token/ERC20/ERC20/harnesses/ERC20FacetHarness.sol
- test/ERC20/harnesses/LibERC20Harness.sol -> test/token/ERC20/ERC20/harnesses/LibERC20Harness.sol

This change improves test organization by grouping all token standards under a common parent directory, making it easier to navigate and maintain as more token standards are added.