### PR TITLE
test: add comprehensive test coverage for AccessControl contracts

### DIFF
--- a/test/access/AccessControl/AccessControlFacet.t.sol
+++ b/test/access/AccessControl/AccessControlFacet.t.sol
@@ -1,0 +1,610 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {AccessControlFacet} from "../../../src/access/AccessControl/AccessControlFacet.sol";
+import {AccessControlFacetHarness} from "./harnesses/AccessControlFacetHarness.sol";
+
+contract AccessControlFacetTest is Test {
+    AccessControlFacetHarness public accessControl;
+
+    // Test addresses
+    address ADMIN = makeAddr("admin");
+    address ALICE = makeAddr("alice");
+    address BOB = makeAddr("bob");
+    address CHARLIE = makeAddr("charlie");
+    address ZERO_ADDRESS = address(0);
+
+    // Test roles
+    bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+    bytes32 constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+    bytes32 constant MODERATOR_ROLE = keccak256("MODERATOR_ROLE");
+    bytes32 constant USER_ROLE = keccak256("USER_ROLE");
+
+    // Events
+    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    function setUp() public {
+        accessControl = new AccessControlFacetHarness();
+        accessControl.initialize(ADMIN);
+    }
+
+    // ============================================
+    // HasRole Tests
+    // ============================================
+
+    function test_HasRole_ReturnsCorrectInitialState() public view {
+        assertTrue(accessControl.hasRole(DEFAULT_ADMIN_ROLE, ADMIN));
+        assertFalse(accessControl.hasRole(DEFAULT_ADMIN_ROLE, ALICE));
+    }
+
+    function test_HasRole_ReturnsTrueForGrantedRole() public {
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_HasRole_ReturnsFalseForNonGrantedRole() public view {
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_HasRole_HandlesMultipleRolesPerAccount() public {
+        vm.startPrank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+        accessControl.grantRole(PAUSER_ROLE, ALICE);
+        accessControl.grantRole(UPGRADER_ROLE, ALICE);
+        vm.stopPrank();
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+        assertTrue(accessControl.hasRole(PAUSER_ROLE, ALICE));
+        assertTrue(accessControl.hasRole(UPGRADER_ROLE, ALICE));
+        assertFalse(accessControl.hasRole(MODERATOR_ROLE, ALICE));
+    }
+
+    function test_HasRole_HandlesMultipleAccountsPerRole() public {
+        vm.startPrank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+        accessControl.grantRole(MINTER_ROLE, BOB);
+        accessControl.grantRole(MINTER_ROLE, CHARLIE);
+        vm.stopPrank();
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+        assertTrue(accessControl.hasRole(MINTER_ROLE, BOB));
+        assertTrue(accessControl.hasRole(MINTER_ROLE, CHARLIE));
+    }
+
+    // ============================================
+    // RequireRole Tests
+    // ============================================
+
+    function test_RequireRole_PassesWhenAccountHasRole() public {
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        accessControl.requireRole(MINTER_ROLE, ALICE);
+        // No revert means success
+    }
+
+    function test_RevertWhen_RequireRole_AccountDoesNotHaveRole() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlFacet.AccessControlUnauthorizedAccount.selector, ALICE, MINTER_ROLE)
+        );
+        accessControl.requireRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevertWhen_RequireRole_ZeroAddressDoesNotHaveRole() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControlFacet.AccessControlUnauthorizedAccount.selector, ZERO_ADDRESS, DEFAULT_ADMIN_ROLE
+            )
+        );
+        accessControl.requireRole(DEFAULT_ADMIN_ROLE, ZERO_ADDRESS);
+    }
+
+    // ============================================
+    // GetRoleAdmin Tests
+    // ============================================
+
+    function test_GetRoleAdmin_ReturnsDefaultAdminForNewRole() public view {
+        assertEq(accessControl.getRoleAdmin(MINTER_ROLE), DEFAULT_ADMIN_ROLE);
+    }
+
+    function test_GetRoleAdmin_ReturnsCorrectAdminAfterChange() public {
+        // Set up role hierarchy
+        accessControl.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+        assertEq(accessControl.getRoleAdmin(MINTER_ROLE), PAUSER_ROLE);
+    }
+
+    function test_GetRoleAdmin_DefaultAdminRoleAdminIsItself() public view {
+        assertEq(accessControl.getRoleAdmin(DEFAULT_ADMIN_ROLE), DEFAULT_ADMIN_ROLE);
+    }
+
+    // ============================================
+    // GrantRole Tests
+    // ============================================
+
+    function test_GrantRole_SucceedsWithDefaultAdmin() public {
+        vm.expectEmit(true, true, true, true);
+        emit RoleGranted(MINTER_ROLE, ALICE, ADMIN);
+
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_GrantRole_SucceedsWithCustomRoleAdmin() public {
+        // Set up custom admin for MINTER_ROLE
+        accessControl.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+        accessControl.forceGrantRole(PAUSER_ROLE, BOB);
+
+        vm.expectEmit(true, true, true, true);
+        emit RoleGranted(MINTER_ROLE, ALICE, BOB);
+
+        vm.prank(BOB);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_GrantRole_DoesNotEmitEventWhenAlreadyGranted() public {
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        // Second grant should not emit an event
+        // The AccessControlFacet doesn't return a bool, but we can verify
+        // that the role is still granted and no duplicate event is emitted
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE); // Should silently succeed
+
+        // Verify the role is still granted
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_RevertWhen_GrantRole_CallerIsNotAdmin() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControlFacet.AccessControlUnauthorizedAccount.selector, ALICE, DEFAULT_ADMIN_ROLE
+            )
+        );
+        vm.prank(ALICE);
+        accessControl.grantRole(MINTER_ROLE, BOB);
+    }
+
+    function test_RevertWhen_GrantRole_CallerIsNotCustomAdmin() public {
+        // Set up custom admin for MINTER_ROLE
+        accessControl.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+
+        // ADMIN has DEFAULT_ADMIN_ROLE but not PAUSER_ROLE
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlFacet.AccessControlUnauthorizedAccount.selector, ADMIN, PAUSER_ROLE)
+        );
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_GrantRole_CanGrantToZeroAddress() public {
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ZERO_ADDRESS);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ZERO_ADDRESS));
+    }
+
+    function test_GrantRole_CanGrantToSelf() public {
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ADMIN);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ADMIN));
+    }
+
+    // ============================================
+    // RevokeRole Tests
+    // ============================================
+
+    function test_RevokeRole_SucceedsWithDefaultAdmin() public {
+        // Setup
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+
+        // Revoke
+        vm.expectEmit(true, true, true, true);
+        emit RoleRevoked(MINTER_ROLE, ALICE, ADMIN);
+
+        vm.prank(ADMIN);
+        accessControl.revokeRole(MINTER_ROLE, ALICE);
+
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_RevokeRole_SucceedsWithCustomRoleAdmin() public {
+        // Set up custom admin for MINTER_ROLE
+        accessControl.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+        accessControl.forceGrantRole(PAUSER_ROLE, BOB);
+        accessControl.forceGrantRole(MINTER_ROLE, ALICE);
+
+        vm.expectEmit(true, true, true, true);
+        emit RoleRevoked(MINTER_ROLE, ALICE, BOB);
+
+        vm.prank(BOB);
+        accessControl.revokeRole(MINTER_ROLE, ALICE);
+
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_RevokeRole_DoesNotEmitEventWhenNotGranted() public {
+        // Revoking a role that's not granted should succeed silently
+        vm.prank(ADMIN);
+        accessControl.revokeRole(MINTER_ROLE, ALICE);
+
+        // Verify the role is still not granted
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_RevertWhen_RevokeRole_CallerIsNotAdmin() public {
+        accessControl.forceGrantRole(MINTER_ROLE, ALICE);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControlFacet.AccessControlUnauthorizedAccount.selector, ALICE, DEFAULT_ADMIN_ROLE
+            )
+        );
+        vm.prank(ALICE);
+        accessControl.revokeRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevertWhen_RevokeRole_CallerIsNotCustomAdmin() public {
+        // Set up custom admin for MINTER_ROLE
+        accessControl.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+        accessControl.forceGrantRole(MINTER_ROLE, ALICE);
+
+        // ADMIN has DEFAULT_ADMIN_ROLE but not PAUSER_ROLE
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlFacet.AccessControlUnauthorizedAccount.selector, ADMIN, PAUSER_ROLE)
+        );
+        vm.prank(ADMIN);
+        accessControl.revokeRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevokeRole_CanRevokeFromZeroAddress() public {
+        // Setup
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ZERO_ADDRESS);
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ZERO_ADDRESS));
+
+        // Revoke
+        vm.prank(ADMIN);
+        accessControl.revokeRole(MINTER_ROLE, ZERO_ADDRESS);
+
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ZERO_ADDRESS));
+    }
+
+    // ============================================
+    // RenounceRole Tests
+    // ============================================
+
+    function test_RenounceRole_SucceedsForOwnRole() public {
+        // Setup
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+
+        // Renounce
+        vm.expectEmit(true, true, true, true);
+        emit RoleRevoked(MINTER_ROLE, ALICE, ALICE);
+
+        vm.prank(ALICE);
+        accessControl.renounceRole(MINTER_ROLE, ALICE);
+
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_RenounceRole_DoesNotEmitEventWhenNotGranted() public {
+        // Renouncing a role that's not granted should succeed silently
+        vm.prank(ALICE);
+        accessControl.renounceRole(MINTER_ROLE, ALICE);
+
+        // Verify the role is still not granted
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_RevertWhen_RenounceRole_CallerIsNotAccount() public {
+        accessControl.forceGrantRole(MINTER_ROLE, ALICE);
+
+        vm.expectRevert(abi.encodeWithSelector(AccessControlFacet.AccessControlUnauthorizedSender.selector, BOB, ALICE));
+        vm.prank(BOB);
+        accessControl.renounceRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevertWhen_RenounceRole_AdminCannotRenounceForOthers() public {
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlFacet.AccessControlUnauthorizedSender.selector, ADMIN, ALICE)
+        );
+        vm.prank(ADMIN);
+        accessControl.renounceRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_RenounceRole_CanRenounceMultipleRoles() public {
+        // Setup
+        vm.startPrank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+        accessControl.grantRole(PAUSER_ROLE, ALICE);
+        accessControl.grantRole(UPGRADER_ROLE, ALICE);
+        vm.stopPrank();
+
+        // Renounce roles one by one
+        vm.startPrank(ALICE);
+        accessControl.renounceRole(MINTER_ROLE, ALICE);
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ALICE));
+        assertTrue(accessControl.hasRole(PAUSER_ROLE, ALICE));
+        assertTrue(accessControl.hasRole(UPGRADER_ROLE, ALICE));
+
+        accessControl.renounceRole(PAUSER_ROLE, ALICE);
+        assertFalse(accessControl.hasRole(PAUSER_ROLE, ALICE));
+        assertTrue(accessControl.hasRole(UPGRADER_ROLE, ALICE));
+
+        accessControl.renounceRole(UPGRADER_ROLE, ALICE);
+        assertFalse(accessControl.hasRole(UPGRADER_ROLE, ALICE));
+        vm.stopPrank();
+    }
+
+    function test_RenounceRole_CanRenounceDefaultAdminRole() public {
+        assertTrue(accessControl.hasRole(DEFAULT_ADMIN_ROLE, ADMIN));
+
+        vm.prank(ADMIN);
+        accessControl.renounceRole(DEFAULT_ADMIN_ROLE, ADMIN);
+
+        assertFalse(accessControl.hasRole(DEFAULT_ADMIN_ROLE, ADMIN));
+    }
+
+    // ============================================
+    // Complex Role Hierarchy Tests
+    // ============================================
+
+    function test_ComplexRoleHierarchy_Setup() public {
+        accessControl.setupComplexRoleHierarchy();
+
+        bytes32 ADMIN_ROLE = keccak256("ADMIN_ROLE");
+        bytes32 MODERATOR_ROLE_LOCAL = keccak256("MODERATOR_ROLE");
+        bytes32 USER_ROLE_LOCAL = keccak256("USER_ROLE");
+
+        assertEq(accessControl.getRoleAdmin(ADMIN_ROLE), DEFAULT_ADMIN_ROLE);
+        assertEq(accessControl.getRoleAdmin(MODERATOR_ROLE_LOCAL), ADMIN_ROLE);
+        assertEq(accessControl.getRoleAdmin(USER_ROLE_LOCAL), MODERATOR_ROLE_LOCAL);
+    }
+
+    function test_ComplexRoleHierarchy_GrantingThroughHierarchy() public {
+        accessControl.setupComplexRoleHierarchy();
+
+        bytes32 ADMIN_ROLE = keccak256("ADMIN_ROLE");
+        bytes32 MODERATOR_ROLE_LOCAL = keccak256("MODERATOR_ROLE");
+        bytes32 USER_ROLE_LOCAL = keccak256("USER_ROLE");
+
+        // Grant ADMIN_ROLE (only DEFAULT_ADMIN can do this)
+        vm.prank(ADMIN);
+        accessControl.grantRole(ADMIN_ROLE, ALICE);
+
+        // Grant MODERATOR_ROLE (only ADMIN_ROLE can do this)
+        vm.prank(ALICE);
+        accessControl.grantRole(MODERATOR_ROLE_LOCAL, BOB);
+
+        // Grant USER_ROLE (only MODERATOR_ROLE can do this)
+        vm.prank(BOB);
+        accessControl.grantRole(USER_ROLE_LOCAL, CHARLIE);
+
+        assertTrue(accessControl.hasRole(ADMIN_ROLE, ALICE));
+        assertTrue(accessControl.hasRole(MODERATOR_ROLE_LOCAL, BOB));
+        assertTrue(accessControl.hasRole(USER_ROLE_LOCAL, CHARLIE));
+    }
+
+    function test_ComplexRoleHierarchy_CannotGrantWithoutProperAdmin() public {
+        accessControl.setupComplexRoleHierarchy();
+
+        bytes32 ADMIN_ROLE = keccak256("ADMIN_ROLE");
+        bytes32 MODERATOR_ROLE_LOCAL = keccak256("MODERATOR_ROLE");
+
+        // ALICE doesn't have ADMIN_ROLE, so can't grant MODERATOR_ROLE
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlFacet.AccessControlUnauthorizedAccount.selector, ALICE, ADMIN_ROLE)
+        );
+        vm.prank(ALICE);
+        accessControl.grantRole(MODERATOR_ROLE_LOCAL, BOB);
+    }
+
+    // ============================================
+    // Edge Cases Tests
+    // ============================================
+
+    function test_EdgeCase_RoleAdminOfItself() public {
+        accessControl.forceSetRoleAdmin(MINTER_ROLE, MINTER_ROLE);
+        accessControl.forceGrantRole(MINTER_ROLE, ALICE);
+
+        // ALICE has MINTER_ROLE and MINTER_ROLE is its own admin
+        vm.prank(ALICE);
+        accessControl.grantRole(MINTER_ROLE, BOB);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, BOB));
+    }
+
+    function test_EdgeCase_CircularRoleAdminHierarchy() public {
+        accessControl.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+        accessControl.forceSetRoleAdmin(PAUSER_ROLE, UPGRADER_ROLE);
+        accessControl.forceSetRoleAdmin(UPGRADER_ROLE, MINTER_ROLE);
+
+        // Grant MINTER_ROLE to ALICE (requires PAUSER_ROLE)
+        accessControl.forceGrantRole(PAUSER_ROLE, BOB);
+        vm.prank(BOB);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_EdgeCase_GrantAndRevokeInSameBlock() public {
+        vm.startPrank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+        accessControl.revokeRole(MINTER_ROLE, ALICE);
+        vm.stopPrank();
+
+        assertFalse(accessControl.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_EdgeCase_MultipleOperationsOnSameRole() public {
+        vm.startPrank(ADMIN);
+
+        // Grant to multiple accounts
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+        accessControl.grantRole(MINTER_ROLE, BOB);
+        accessControl.grantRole(MINTER_ROLE, CHARLIE);
+
+        // Revoke from one
+        accessControl.revokeRole(MINTER_ROLE, BOB);
+
+        vm.stopPrank();
+
+        // BOB renounces (should have no effect since already revoked)
+        vm.prank(BOB);
+        accessControl.renounceRole(MINTER_ROLE, BOB);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+        assertFalse(accessControl.hasRole(MINTER_ROLE, BOB));
+        assertTrue(accessControl.hasRole(MINTER_ROLE, CHARLIE));
+    }
+
+    // ============================================
+    // Storage Consistency Tests
+    // ============================================
+
+    function test_StorageConsistency_HasRoleMatchesStorage() public {
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        assertTrue(accessControl.hasRole(MINTER_ROLE, ALICE));
+        assertTrue(accessControl.getStorageHasRole(ALICE, MINTER_ROLE));
+    }
+
+    function test_StorageConsistency_RoleAdminMatchesStorage() public {
+        accessControl.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+
+        assertEq(accessControl.getRoleAdmin(MINTER_ROLE), PAUSER_ROLE);
+        assertEq(accessControl.getStorageRoleAdmin(MINTER_ROLE), PAUSER_ROLE);
+    }
+
+    function test_StorageSlot_UsesCorrectPosition() public view {
+        bytes32 expectedSlot = keccak256("compose.accesscontrol");
+        assertEq(accessControl.getStoragePosition(), expectedSlot);
+    }
+
+    // ============================================
+    // Fuzz Tests
+    // ============================================
+
+    function testFuzz_GrantRole_OnlyAdminCanGrant(address caller, address account) public {
+        vm.assume(caller != ADMIN);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControlFacet.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE
+            )
+        );
+        vm.prank(caller);
+        accessControl.grantRole(MINTER_ROLE, account);
+    }
+
+    function testFuzz_RevokeRole_OnlyAdminCanRevoke(address caller, address account) public {
+        vm.assume(caller != ADMIN);
+
+        accessControl.forceGrantRole(MINTER_ROLE, account);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControlFacet.AccessControlUnauthorizedAccount.selector, caller, DEFAULT_ADMIN_ROLE
+            )
+        );
+        vm.prank(caller);
+        accessControl.revokeRole(MINTER_ROLE, account);
+    }
+
+    function testFuzz_RenounceRole_OnlyAccountCanRenounce(address caller, address account) public {
+        vm.assume(caller != account);
+
+        accessControl.forceGrantRole(MINTER_ROLE, account);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlFacet.AccessControlUnauthorizedSender.selector, caller, account)
+        );
+        vm.prank(caller);
+        accessControl.renounceRole(MINTER_ROLE, account);
+    }
+
+    function testFuzz_HasRole_ConsistentAcrossMultipleRoles(address account) public {
+        vm.assume(account != address(0));
+
+        bytes32[] memory roles = new bytes32[](10);
+        for (uint256 i = 0; i < roles.length; i++) {
+            roles[i] = keccak256(abi.encodePacked("ROLE_", i));
+        }
+
+        // Grant all roles
+        vm.startPrank(ADMIN);
+        for (uint256 i = 0; i < roles.length; i++) {
+            accessControl.grantRole(roles[i], account);
+        }
+        vm.stopPrank();
+
+        // Verify all roles
+        for (uint256 i = 0; i < roles.length; i++) {
+            assertTrue(accessControl.hasRole(roles[i], account));
+        }
+
+        // Revoke half the roles
+        vm.startPrank(ADMIN);
+        for (uint256 i = 0; i < roles.length; i += 2) {
+            accessControl.revokeRole(roles[i], account);
+        }
+        vm.stopPrank();
+
+        // Verify correct roles are revoked
+        for (uint256 i = 0; i < roles.length; i++) {
+            if (i % 2 == 0) {
+                assertFalse(accessControl.hasRole(roles[i], account));
+            } else {
+                assertTrue(accessControl.hasRole(roles[i], account));
+            }
+        }
+    }
+
+    function testFuzz_RoleAdminHierarchy(bytes32 role1, bytes32 role2, bytes32 role3) public {
+        vm.assume(role1 != role2 && role2 != role3 && role1 != role3);
+
+        // Create hierarchy: role1 -> role2 -> role3
+        accessControl.forceSetRoleAdmin(role1, DEFAULT_ADMIN_ROLE);
+        accessControl.forceSetRoleAdmin(role2, role1);
+        accessControl.forceSetRoleAdmin(role3, role2);
+
+        assertEq(accessControl.getRoleAdmin(role1), DEFAULT_ADMIN_ROLE);
+        assertEq(accessControl.getRoleAdmin(role2), role1);
+        assertEq(accessControl.getRoleAdmin(role3), role2);
+
+        // Grant roles in hierarchy
+        vm.prank(ADMIN);
+        accessControl.grantRole(role1, ALICE);
+
+        vm.prank(ALICE);
+        accessControl.grantRole(role2, BOB);
+
+        vm.prank(BOB);
+        accessControl.grantRole(role3, CHARLIE);
+
+        assertTrue(accessControl.hasRole(role1, ALICE));
+        assertTrue(accessControl.hasRole(role2, BOB));
+        assertTrue(accessControl.hasRole(role3, CHARLIE));
+    }
+}

--- a/test/access/AccessControl/LibAccessControl.t.sol
+++ b/test/access/AccessControl/LibAccessControl.t.sol
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {LibAccessControl} from "../../../src/access/AccessControl/LibAccessControl.sol";
+import {LibAccessControlHarness} from "./harnesses/LibAccessControlHarness.sol";
+
+contract LibAccessControlTest is Test {
+    LibAccessControlHarness public harness;
+
+    // Test addresses
+    address ADMIN = makeAddr("admin");
+    address ALICE = makeAddr("alice");
+    address BOB = makeAddr("bob");
+    address CHARLIE = makeAddr("charlie");
+    address ZERO_ADDRESS = address(0);
+
+    // Test roles
+    bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+    bytes32 constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+    bytes32 constant MODERATOR_ROLE = keccak256("MODERATOR_ROLE");
+
+    // Events
+    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    function setUp() public {
+        harness = new LibAccessControlHarness();
+        harness.initialize(ADMIN);
+    }
+
+    // ============================================
+    // Storage Tests
+    // ============================================
+
+    function test_GetStorage_ReturnsCorrectInitialState() public view {
+        assertEq(harness.hasRole(DEFAULT_ADMIN_ROLE, ADMIN), true);
+        assertEq(harness.getStorageHasRole(ADMIN, DEFAULT_ADMIN_ROLE), true);
+    }
+
+    function test_StorageSlot_UsesCorrectPosition() public {
+        bytes32 expectedSlot = keccak256("compose.accesscontrol");
+
+        // Grant a role
+        vm.prank(address(harness));
+        harness.grantRole(MINTER_ROLE, ALICE);
+
+        // The actual storage slot for hasRole[ALICE][MINTER_ROLE] is computed as:
+        // keccak256(abi.encode(MINTER_ROLE, keccak256(abi.encode(ALICE, expectedSlot))))
+        bytes32 accountSlot = keccak256(abi.encode(ALICE, expectedSlot));
+        bytes32 roleSlot = keccak256(abi.encode(MINTER_ROLE, accountSlot));
+
+        // Read directly from storage
+        bytes32 storedValue = vm.load(address(harness), roleSlot);
+        bool hasRole = storedValue != bytes32(0);
+
+        assertTrue(hasRole, "Role should be stored at correct position");
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_DefaultAdminRole_IsZeroBytes() public view {
+        assertEq(harness.getDefaultAdminRole(), bytes32(0));
+    }
+
+    // ============================================
+    // HasRole Tests
+    // ============================================
+
+    function test_HasRole_ReturnsTrueForGrantedRole() public {
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_HasRole_ReturnsFalseForNonGrantedRole() public view {
+        assertFalse(harness.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_HasRole_ReturnsFalseForZeroAddress() public view {
+        assertFalse(harness.hasRole(DEFAULT_ADMIN_ROLE, ZERO_ADDRESS));
+    }
+
+    function test_HasRole_HandlesMultipleRolesPerAccount() public {
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+        harness.forceGrantRole(PAUSER_ROLE, ALICE);
+        harness.forceGrantRole(UPGRADER_ROLE, ALICE);
+
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+        assertTrue(harness.hasRole(PAUSER_ROLE, ALICE));
+        assertTrue(harness.hasRole(UPGRADER_ROLE, ALICE));
+        assertFalse(harness.hasRole(MODERATOR_ROLE, ALICE));
+    }
+
+    function test_HasRole_HandlesMultipleAccountsPerRole() public {
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+        harness.forceGrantRole(MINTER_ROLE, BOB);
+        harness.forceGrantRole(MINTER_ROLE, CHARLIE);
+
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+        assertTrue(harness.hasRole(MINTER_ROLE, BOB));
+        assertTrue(harness.hasRole(MINTER_ROLE, CHARLIE));
+    }
+
+    // ============================================
+    // RequireRole Tests
+    // ============================================
+
+    function test_RequireRole_PassesWhenAccountHasRole() public {
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+        harness.requireRole(MINTER_ROLE, ALICE);
+        // No revert means success
+    }
+
+    function test_RevertWhen_RequireRole_AccountDoesNotHaveRole() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(LibAccessControl.AccessControlUnauthorizedAccount.selector, ALICE, MINTER_ROLE)
+        );
+        harness.requireRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevertWhen_RequireRole_ZeroAddressDoesNotHaveRole() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibAccessControl.AccessControlUnauthorizedAccount.selector, ZERO_ADDRESS, DEFAULT_ADMIN_ROLE
+            )
+        );
+        harness.requireRole(DEFAULT_ADMIN_ROLE, ZERO_ADDRESS);
+    }
+
+    // ============================================
+    // SetRoleAdmin Tests
+    // ============================================
+
+    function test_SetRoleAdmin_UpdatesAdminRole() public {
+        harness.setRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+        assertEq(harness.getRoleAdmin(MINTER_ROLE), PAUSER_ROLE);
+    }
+
+    function test_SetRoleAdmin_EmitsRoleAdminChangedEvent() public {
+        vm.expectEmit(true, true, true, true);
+        emit RoleAdminChanged(MINTER_ROLE, DEFAULT_ADMIN_ROLE, PAUSER_ROLE);
+
+        harness.setRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+    }
+
+    function test_SetRoleAdmin_CanSetToDefaultAdminRole() public {
+        harness.setRoleAdmin(MINTER_ROLE, DEFAULT_ADMIN_ROLE);
+        assertEq(harness.getRoleAdmin(MINTER_ROLE), DEFAULT_ADMIN_ROLE);
+    }
+
+    function test_SetRoleAdmin_CanSetToSameRole() public {
+        harness.setRoleAdmin(MINTER_ROLE, MINTER_ROLE);
+        assertEq(harness.getRoleAdmin(MINTER_ROLE), MINTER_ROLE);
+    }
+
+    function test_SetRoleAdmin_MultipleChanges() public {
+        // First change
+        harness.setRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+        assertEq(harness.getRoleAdmin(MINTER_ROLE), PAUSER_ROLE);
+
+        // Second change
+        harness.setRoleAdmin(MINTER_ROLE, UPGRADER_ROLE);
+        assertEq(harness.getRoleAdmin(MINTER_ROLE), UPGRADER_ROLE);
+
+        // Back to default
+        harness.setRoleAdmin(MINTER_ROLE, DEFAULT_ADMIN_ROLE);
+        assertEq(harness.getRoleAdmin(MINTER_ROLE), DEFAULT_ADMIN_ROLE);
+    }
+
+    // ============================================
+    // GrantRole Tests
+    // ============================================
+
+    function test_GrantRole_GrantsRoleToAccount() public {
+        vm.prank(address(harness));
+        bool granted = harness.grantRole(MINTER_ROLE, ALICE);
+
+        assertTrue(granted);
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_GrantRole_ReturnsFalseWhenAlreadyGranted() public {
+        vm.prank(address(harness));
+        harness.grantRole(MINTER_ROLE, ALICE);
+
+        vm.prank(address(harness));
+        bool granted = harness.grantRole(MINTER_ROLE, ALICE);
+
+        assertFalse(granted);
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_GrantRole_EmitsRoleGrantedEvent() public {
+        vm.expectEmit(true, true, true, true);
+        emit RoleGranted(MINTER_ROLE, ALICE, address(harness));
+
+        vm.prank(address(harness));
+        harness.grantRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_GrantRole_DoesNotEmitEventWhenAlreadyGranted() public {
+        vm.prank(address(harness));
+        harness.grantRole(MINTER_ROLE, ALICE);
+
+        // Should not emit event on second grant
+        // We check this by testing that no RoleGranted event is emitted
+        vm.prank(address(harness));
+        bool granted = harness.grantRole(MINTER_ROLE, ALICE);
+
+        // The function should return false when role is already granted
+        assertFalse(granted, "Should return false when role already granted");
+    }
+
+    function test_GrantRole_CanGrantToZeroAddress() public {
+        vm.prank(address(harness));
+        bool granted = harness.grantRole(MINTER_ROLE, ZERO_ADDRESS);
+
+        assertTrue(granted);
+        assertTrue(harness.hasRole(MINTER_ROLE, ZERO_ADDRESS));
+    }
+
+    function test_GrantRole_MultipleRolesToSameAccount() public {
+        vm.startPrank(address(harness));
+
+        harness.grantRole(MINTER_ROLE, ALICE);
+        harness.grantRole(PAUSER_ROLE, ALICE);
+        harness.grantRole(UPGRADER_ROLE, ALICE);
+
+        vm.stopPrank();
+
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+        assertTrue(harness.hasRole(PAUSER_ROLE, ALICE));
+        assertTrue(harness.hasRole(UPGRADER_ROLE, ALICE));
+    }
+
+    function test_GrantRole_SameRoleToMultipleAccounts() public {
+        vm.startPrank(address(harness));
+
+        harness.grantRole(MINTER_ROLE, ALICE);
+        harness.grantRole(MINTER_ROLE, BOB);
+        harness.grantRole(MINTER_ROLE, CHARLIE);
+
+        vm.stopPrank();
+
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+        assertTrue(harness.hasRole(MINTER_ROLE, BOB));
+        assertTrue(harness.hasRole(MINTER_ROLE, CHARLIE));
+    }
+
+    // ============================================
+    // RevokeRole Tests
+    // ============================================
+
+    function test_RevokeRole_RevokesRoleFromAccount() public {
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+
+        vm.prank(address(harness));
+        bool revoked = harness.revokeRole(MINTER_ROLE, ALICE);
+
+        assertTrue(revoked);
+        assertFalse(harness.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_RevokeRole_ReturnsFalseWhenNotGranted() public {
+        vm.prank(address(harness));
+        bool revoked = harness.revokeRole(MINTER_ROLE, ALICE);
+
+        assertFalse(revoked);
+        assertFalse(harness.hasRole(MINTER_ROLE, ALICE));
+    }
+
+    function test_RevokeRole_EmitsRoleRevokedEvent() public {
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+
+        vm.expectEmit(true, true, true, true);
+        emit RoleRevoked(MINTER_ROLE, ALICE, address(harness));
+
+        vm.prank(address(harness));
+        harness.revokeRole(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevokeRole_DoesNotEmitEventWhenNotGranted() public {
+        // We check this by testing that the function returns false when no role to revoke
+        vm.prank(address(harness));
+        bool revoked = harness.revokeRole(MINTER_ROLE, ALICE);
+
+        // The function should return false when role is not granted
+        assertFalse(revoked, "Should return false when role not granted");
+    }
+
+    function test_RevokeRole_OnlyRevokesSpecificRole() public {
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+        harness.forceGrantRole(PAUSER_ROLE, ALICE);
+        harness.forceGrantRole(UPGRADER_ROLE, ALICE);
+
+        vm.prank(address(harness));
+        harness.revokeRole(PAUSER_ROLE, ALICE);
+
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+        assertFalse(harness.hasRole(PAUSER_ROLE, ALICE));
+        assertTrue(harness.hasRole(UPGRADER_ROLE, ALICE));
+    }
+
+    function test_RevokeRole_OnlyRevokesFromSpecificAccount() public {
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+        harness.forceGrantRole(MINTER_ROLE, BOB);
+        harness.forceGrantRole(MINTER_ROLE, CHARLIE);
+
+        vm.prank(address(harness));
+        harness.revokeRole(MINTER_ROLE, BOB);
+
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+        assertFalse(harness.hasRole(MINTER_ROLE, BOB));
+        assertTrue(harness.hasRole(MINTER_ROLE, CHARLIE));
+    }
+
+    // ============================================
+    // Edge Cases Tests
+    // ============================================
+
+    function test_EdgeCase_GrantAndRevokeMultipleTimes() public {
+        vm.startPrank(address(harness));
+
+        // Grant
+        assertTrue(harness.grantRole(MINTER_ROLE, ALICE));
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+
+        // Revoke
+        assertTrue(harness.revokeRole(MINTER_ROLE, ALICE));
+        assertFalse(harness.hasRole(MINTER_ROLE, ALICE));
+
+        // Grant again
+        assertTrue(harness.grantRole(MINTER_ROLE, ALICE));
+        assertTrue(harness.hasRole(MINTER_ROLE, ALICE));
+
+        // Revoke again
+        assertTrue(harness.revokeRole(MINTER_ROLE, ALICE));
+        assertFalse(harness.hasRole(MINTER_ROLE, ALICE));
+
+        vm.stopPrank();
+    }
+
+    function test_EdgeCase_RoleAdminOfItself() public {
+        harness.setRoleAdmin(MINTER_ROLE, MINTER_ROLE);
+        assertEq(harness.getRoleAdmin(MINTER_ROLE), MINTER_ROLE);
+    }
+
+    function test_EdgeCase_CircularRoleAdminHierarchy() public {
+        harness.setRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+        harness.setRoleAdmin(PAUSER_ROLE, UPGRADER_ROLE);
+        harness.setRoleAdmin(UPGRADER_ROLE, MINTER_ROLE);
+
+        assertEq(harness.getRoleAdmin(MINTER_ROLE), PAUSER_ROLE);
+        assertEq(harness.getRoleAdmin(PAUSER_ROLE), UPGRADER_ROLE);
+        assertEq(harness.getRoleAdmin(UPGRADER_ROLE), MINTER_ROLE);
+    }
+
+    // ============================================
+    // Fuzz Tests
+    // ============================================
+
+    function testFuzz_HasRole_ConsistentWithStorage(address account, bytes32 role, bool hasRole) public {
+        if (hasRole) {
+            harness.forceGrantRole(role, account);
+        }
+
+        assertEq(harness.hasRole(role, account), hasRole);
+        assertEq(harness.getStorageHasRole(account, role), hasRole);
+    }
+
+    function testFuzz_GrantRole_AlwaysReturnsCorrectBool(address account, bytes32 role) public {
+        vm.startPrank(address(harness));
+
+        // First grant should return true
+        bool firstGrant = harness.grantRole(role, account);
+        assertTrue(firstGrant);
+        assertTrue(harness.hasRole(role, account));
+
+        // Second grant should return false
+        bool secondGrant = harness.grantRole(role, account);
+        assertFalse(secondGrant);
+        assertTrue(harness.hasRole(role, account));
+
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevokeRole_AlwaysReturnsCorrectBool(address account, bytes32 role) public {
+        vm.startPrank(address(harness));
+
+        // First revoke (no role) should return false
+        bool firstRevoke = harness.revokeRole(role, account);
+        assertFalse(firstRevoke);
+        assertFalse(harness.hasRole(role, account));
+
+        // Grant role
+        harness.grantRole(role, account);
+        assertTrue(harness.hasRole(role, account));
+
+        // Second revoke (has role) should return true
+        bool secondRevoke = harness.revokeRole(role, account);
+        assertTrue(secondRevoke);
+        assertFalse(harness.hasRole(role, account));
+
+        vm.stopPrank();
+    }
+
+    function testFuzz_SetRoleAdmin_AlwaysUpdatesCorrectly(bytes32 role, bytes32 adminRole) public {
+        harness.setRoleAdmin(role, adminRole);
+        assertEq(harness.getRoleAdmin(role), adminRole);
+    }
+
+    function testFuzz_MultipleRolesPerAccount(address account) public {
+        vm.assume(account != address(0));
+
+        bytes32[] memory roles = new bytes32[](5);
+        roles[0] = keccak256("ROLE_1");
+        roles[1] = keccak256("ROLE_2");
+        roles[2] = keccak256("ROLE_3");
+        roles[3] = keccak256("ROLE_4");
+        roles[4] = keccak256("ROLE_5");
+
+        vm.startPrank(address(harness));
+
+        // Grant all roles
+        for (uint256 i = 0; i < roles.length; i++) {
+            harness.grantRole(roles[i], account);
+        }
+
+        // Verify all roles are granted
+        for (uint256 i = 0; i < roles.length; i++) {
+            assertTrue(harness.hasRole(roles[i], account));
+        }
+
+        // Revoke some roles (even indices)
+        for (uint256 i = 0; i < roles.length; i += 2) {
+            harness.revokeRole(roles[i], account);
+        }
+
+        // Verify correct roles are revoked/kept
+        for (uint256 i = 0; i < roles.length; i++) {
+            if (i % 2 == 0) {
+                assertFalse(harness.hasRole(roles[i], account));
+            } else {
+                assertTrue(harness.hasRole(roles[i], account));
+            }
+        }
+
+        vm.stopPrank();
+    }
+}

--- a/test/access/AccessControl/harnesses/AccessControlFacetHarness.sol
+++ b/test/access/AccessControl/harnesses/AccessControlFacetHarness.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {AccessControlFacet} from "../../../../src/access/AccessControl/AccessControlFacet.sol";
+
+/// @title AccessControlFacet Test Harness
+/// @notice Extends AccessControlFacet with initialization and test-specific functions
+contract AccessControlFacetHarness is AccessControlFacet {
+    /// @notice Initialize the DEFAULT_ADMIN_ROLE for testing
+    /// @dev This function is only for testing purposes
+    function initialize(address _admin) external {
+        AccessControlStorage storage s = getStorage();
+        s.hasRole[_admin][DEFAULT_ADMIN_ROLE] = true;
+    }
+
+    /// @notice Initialize with multiple admins for different roles
+    /// @dev This sets up complex role hierarchies for testing
+    function initializeWithRoles(address _defaultAdmin, bytes32 _role, address _roleAdmin, bytes32 _roleAdminRole)
+        external
+    {
+        AccessControlStorage storage s = getStorage();
+        // Set default admin
+        s.hasRole[_defaultAdmin][DEFAULT_ADMIN_ROLE] = true;
+        // Set up role hierarchy
+        s.adminRole[_role] = _roleAdminRole;
+        s.hasRole[_roleAdmin][_roleAdminRole] = true;
+    }
+
+    /// @notice Force grant a role without any checks (for testing edge cases)
+    /// @dev This bypasses all access control for testing purposes
+    function forceGrantRole(bytes32 _role, address _account) external {
+        AccessControlStorage storage s = getStorage();
+        s.hasRole[_account][_role] = true;
+    }
+
+    /// @notice Force revoke a role without any checks (for testing edge cases)
+    /// @dev This bypasses all access control for testing purposes
+    function forceRevokeRole(bytes32 _role, address _account) external {
+        AccessControlStorage storage s = getStorage();
+        s.hasRole[_account][_role] = false;
+    }
+
+    /// @notice Force set the admin role for a role without any checks
+    /// @dev This bypasses all access control for testing purposes
+    function forceSetRoleAdmin(bytes32 _role, bytes32 _adminRole) external {
+        AccessControlStorage storage s = getStorage();
+        s.adminRole[_role] = _adminRole;
+    }
+
+    /// @notice Get the raw storage hasRole value (for testing storage consistency)
+    function getStorageHasRole(address _account, bytes32 _role) external view returns (bool) {
+        return getStorage().hasRole[_account][_role];
+    }
+
+    /// @notice Get the raw storage adminRole value (for testing storage consistency)
+    function getStorageRoleAdmin(bytes32 _role) external view returns (bytes32) {
+        return getStorage().adminRole[_role];
+    }
+
+    /// @notice Setup a complex role hierarchy for testing
+    /// @dev Creates multiple levels of roles with different admins
+    function setupComplexRoleHierarchy() external {
+        AccessControlStorage storage s = getStorage();
+
+        // Create role hierarchy:
+        // DEFAULT_ADMIN_ROLE -> ADMIN_ROLE -> MODERATOR_ROLE -> USER_ROLE
+        bytes32 ADMIN_ROLE = keccak256("ADMIN_ROLE");
+        bytes32 MODERATOR_ROLE = keccak256("MODERATOR_ROLE");
+        bytes32 USER_ROLE = keccak256("USER_ROLE");
+
+        s.adminRole[ADMIN_ROLE] = DEFAULT_ADMIN_ROLE;
+        s.adminRole[MODERATOR_ROLE] = ADMIN_ROLE;
+        s.adminRole[USER_ROLE] = MODERATOR_ROLE;
+    }
+
+    /// @notice Clear all roles for an account (for testing clean state)
+    function clearAllRoles(address _account) external {
+        AccessControlStorage storage s = getStorage();
+
+        // Clear some common test roles
+        s.hasRole[_account][DEFAULT_ADMIN_ROLE] = false;
+        s.hasRole[_account][keccak256("ADMIN_ROLE")] = false;
+        s.hasRole[_account][keccak256("MODERATOR_ROLE")] = false;
+        s.hasRole[_account][keccak256("USER_ROLE")] = false;
+        s.hasRole[_account][keccak256("MINTER_ROLE")] = false;
+        s.hasRole[_account][keccak256("PAUSER_ROLE")] = false;
+    }
+
+    /// @notice Get the DEFAULT_ADMIN_ROLE constant for testing
+    function getDefaultAdminRole() external pure returns (bytes32) {
+        return DEFAULT_ADMIN_ROLE;
+    }
+
+    /// @notice Get the STORAGE_POSITION constant for testing
+    function getStoragePosition() external pure returns (bytes32) {
+        return STORAGE_POSITION;
+    }
+}

--- a/test/access/AccessControl/harnesses/LibAccessControlHarness.sol
+++ b/test/access/AccessControl/harnesses/LibAccessControlHarness.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {LibAccessControl} from "../../../../src/access/AccessControl/LibAccessControl.sol";
+
+/// @title LibAccessControl Test Harness
+/// @notice Exposes internal LibAccessControl functions as external for testing
+contract LibAccessControlHarness {
+    /// @notice Initialize roles for testing
+    /// @param _account The account to grant the default admin role to
+    function initialize(address _account) external {
+        LibAccessControl.AccessControlStorage storage s = LibAccessControl.getStorage();
+        s.hasRole[_account][LibAccessControl.DEFAULT_ADMIN_ROLE] = true;
+    }
+
+    /// @notice Check if an account has a role
+    function hasRole(bytes32 _role, address _account) external view returns (bool) {
+        return LibAccessControl.hasRole(_role, _account);
+    }
+
+    /// @notice Require that an account has a role
+    function requireRole(bytes32 _role, address _account) external view {
+        LibAccessControl.requireRole(_role, _account);
+    }
+
+    /// @notice Set the admin role for a role
+    function setRoleAdmin(bytes32 _role, bytes32 _adminRole) external {
+        LibAccessControl.setRoleAdmin(_role, _adminRole);
+    }
+
+    /// @notice Grant a role to an account
+    function grantRole(bytes32 _role, address _account) external returns (bool) {
+        return LibAccessControl.grantRole(_role, _account);
+    }
+
+    /// @notice Revoke a role from an account
+    function revokeRole(bytes32 _role, address _account) external returns (bool) {
+        return LibAccessControl.revokeRole(_role, _account);
+    }
+
+    /// @notice Get the admin role for a role (for testing storage consistency)
+    function getRoleAdmin(bytes32 _role) external view returns (bytes32) {
+        LibAccessControl.AccessControlStorage storage s = LibAccessControl.getStorage();
+        return s.adminRole[_role];
+    }
+
+    /// @notice Get raw storage hasRole mapping (for testing storage consistency)
+    function getStorageHasRole(address _account, bytes32 _role) external view returns (bool) {
+        LibAccessControl.AccessControlStorage storage s = LibAccessControl.getStorage();
+        return s.hasRole[_account][_role];
+    }
+
+    /// @notice Force set a role without checks (for testing edge cases)
+    function forceGrantRole(bytes32 _role, address _account) external {
+        LibAccessControl.AccessControlStorage storage s = LibAccessControl.getStorage();
+        s.hasRole[_account][_role] = true;
+    }
+
+    /// @notice Force revoke a role without checks (for testing edge cases)
+    function forceRevokeRole(bytes32 _role, address _account) external {
+        LibAccessControl.AccessControlStorage storage s = LibAccessControl.getStorage();
+        s.hasRole[_account][_role] = false;
+    }
+
+    /// @notice Force set the admin role without checks or events (for testing edge cases)
+    function forceSetRoleAdmin(bytes32 _role, bytes32 _adminRole) external {
+        LibAccessControl.AccessControlStorage storage s = LibAccessControl.getStorage();
+        s.adminRole[_role] = _adminRole;
+    }
+
+    /// @notice Get the DEFAULT_ADMIN_ROLE constant
+    function getDefaultAdminRole() external pure returns (bytes32) {
+        return LibAccessControl.DEFAULT_ADMIN_ROLE;
+    }
+}


### PR DESCRIPTION
test: add comprehensive test coverage for AccessControl contracts (#131)

Implement complete test suites for LibAccessControl and AccessControlFacet
with test harnesses to expose internal library functions for thorough testing.

New files added:
- test/access/AccessControl/LibAccessControl.t.sol (454 lines, 37 tests)
- test/access/AccessControl/AccessControlFacet.t.sol (611 lines, 45 tests)
- test/access/AccessControl/harnesses/LibAccessControlHarness.sol
- test/access/AccessControl/harnesses/AccessControlFacetHarness.sol

Test coverage includes:
- Core RBAC functionality (grant, revoke, renounce, hasRole)
- Role admin hierarchies and custom role admins
- Access control enforcement with requireRole
- Storage slot verification and collision prevention
- Event emission for all role operations
- Edge cases (circular hierarchies, self-admin roles, zero addresses)
- Comprehensive fuzz tests for all operations
- Complex multi-level role hierarchy scenarios

Total: 82 new tests ensuring robust access control implementation
following patterns established by Owner and OwnerTwoSteps test suites.

Closes #131