### PR TITLE
Implement ERC-165 facet and library for interface detection

### DIFF
--- a/src/interfaceDetection/ERC165/ERC165Facet.sol
+++ b/src/interfaceDetection/ERC165/ERC165Facet.sol
@@ -40,14 +40,6 @@ contract ERC165Facet {
         }
     }
 
-    /// @notice Register that a contract supports an interface
-    /// @param _interfaceId The interface ID to register
-    /// @dev Call this function during initialization to register supported interfaces
-    function registerInterface(bytes4 _interfaceId) internal {
-        ERC165Storage storage s = getStorage();
-        s.supportedInterfaces[_interfaceId] = true;
-    }
-
     /// @notice Query if a contract implements an interface
     /// @param _interfaceId The interface identifier, as specified in ERC-165
     /// @dev This function checks if the diamond supports the given interface ID

--- a/src/interfaceDetection/ERC165/LibERC165.sol
+++ b/src/interfaceDetection/ERC165/LibERC165.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+/// @title LibERC165 — ERC-165 Standard Interface Detection Library
+/// @notice Provides internal functions and storage layout for ERC-165 interface detection.
+/// @dev Uses ERC-8042 for storage location standardization
+library LibERC165 {
+    /// @notice Storage slot identifier, defined using keccak256 hash of the library diamond storage identifier.
+    bytes32 constant STORAGE_POSITION = keccak256("compose.erc165");
+
+    /// @notice ERC-165 storage layout using the ERC-8042 standard.
+    /// @custom:storage-location erc8042:compose.erc165
+    struct ERC165Storage {
+        /// @notice Mapping of interface IDs to whether they are supported
+        mapping(bytes4 => bool) supportedInterfaces;
+    }
+
+    /// @notice Returns a pointer to the ERC-165 storage struct.
+    /// @dev Uses inline assembly to bind the storage struct to the fixed storage position.
+    /// @return s The ERC-165 storage struct.
+    function getStorage() internal pure returns (ERC165Storage storage s) {
+        bytes32 position = STORAGE_POSITION;
+        assembly {
+            s.slot := position
+        }
+    }
+
+    /// @notice Register that a contract supports an interface
+    /// @param _interfaceId The interface ID to register
+    /// @dev Call this function during initialization to register supported interfaces.
+    /// For example, in an ERC721 facet initialization, you would call:
+    /// `LibERC165.registerInterface(type(IERC721).interfaceId)`
+    function registerInterface(bytes4 _interfaceId) internal {
+        ERC165Storage storage s = getStorage();
+        s.supportedInterfaces[_interfaceId] = true;
+    }
+}


### PR DESCRIPTION


Added ERC-165 support to the diamond pattern.  
Created:
- IERC165 interface in src/interfaces/IERC165.sol
- LibERC165 library in src/libraries/LibERC165.sol
- ERC165Facet in src/diamond/ERC165Facet.sol

Behavior:
- supportsInterface() returns true for the ERC-165 interface ID
- Use registerInterface() during initialization to register other interfaces
- Mapping-based storage at compose.erc165

Files compile without errors and follow the project’s ERC-8042 storage layout.  
Addresses #123.