### PR TITLE
feat: implement LibNonReentrancy

### DIFF
--- a/src/libraries/LibNonReentrancy.sol
+++ b/src/libraries/LibNonReentrancy.sol
@@ -20,10 +20,10 @@ library LibNonReentrancy {
     /// @dev This unlocks the entry into a function
     function enter() internal {
         bytes32 position = NON_REENTRANT_SLOT;
-        assembly {
+        assembly ("memory-safe") {
             if tload(position) {
                 mstore(0x00, 0x43a0d067)
-                return(0x00, 0x04)
+                revert(0x00, 0x04)
             }
             tstore(position, 1)
         }


### PR DESCRIPTION
## Summary
Implemented a LIbNonReentrant to prevent reentrancy into functions. It fixes #146 

## Changes Made
Implemented the functions `enter()` and `exit()` that helps in unlocking and locking of a function.

## Checklist

Before submitting this PR, please ensure:

- [X] **Code follows the Solidity feature ban** - No inheritance, constructors, modifiers, public/private variables, external library functions, `using for` directives, or `selfdestruct`

- [X] **Code follows Design Principles** - Readable, uses diamond storage, favors composition over inheritance

- [X] **Code matches the codebase style** - Consistent formatting, documentation, and patterns (e.g. ERC20Facet.sol)

- [X] **Code is formatted with `forge fmt`**

- [X] **Tests are included** - All new functionality has comprehensive tests

- [X] **All tests pass** - Run `forge test` and ensure everything works

- [X] **Documentation updated** - If applicable, update relevant documentation

Make sure to follow the [CONTRIBUTING.md](https://github.com/Perfect-Abstractions/Compose/blob/main/CONTRIBUTING.md) guidelines.

## Additional Notes
<!-- Any additional information, concerns, or questions for reviewers -->
