### PR TITLE
Feat: Add ERC-7802 Facet for Cross-Chain Token Interoperability

### DIFF
--- a/src/ERC20Bridgeable/ERC20BridgeableFacet.sol
+++ b/src/ERC20Bridgeable/ERC20BridgeableFacet.sol
@@ -1,22 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.30;
-
-/// @title ERC-165 Standard Interface Detection Interface
-/// @notice Interface for detecting what interfaces a contract implements
-/// @dev ERC-165 allows contracts to publish their supported interfaces
-interface IERC165 {
-    /// @notice Query if a contract implements an interface
-    /// @param _interfaceId The interface identifier, as specified in ERC-165
-    /// @dev Interface identification is specified in ERC-165. This function
-    /// uses less than 30,000 gas.
-    /// @return `true` if the contract implements `_interfaceId` and
-    /// `_interfaceId` is not 0xffffffff, `false` otherwise
-    function supportsInterface(bytes4 _interfaceId) external view returns (bool);
-}
-
 /// @title ERC20Bridgeable — ERC-7802 Implementation Facet
 /// @notice Provides functions and storage layout for ERC20-Bridgeable token logic.
 /// @dev Uses ERC-8042 for storage location standardization and ERC-6093 for error conventions
+
 contract ERC20BridgeableFacet {
     /// @notice Revert when a provided receiver is invalid(e.g,zero address) .
     /// @param _receiver The invalid reciever address.
@@ -34,12 +21,11 @@ contract ERC20BridgeableFacet {
     /// @param _caller is the invalid address.
     error ERC20InvalidCallerAddress(address _caller);
 
-
     /// @notice Thrown when the account does not have a specific role.
     /// @param _role The role that the account does not have.
     /// @param _account The account that does not have the role.
     error AccessControlUnauthorizedAccount(address _account, bytes32 _role);
-    
+
     error ERC20InsufficientBalance(address _from, uint256 _accountBalance, uint256 _value);
 
     /// @notice Emitted when tokens are minted via a cross-chain bridge.
@@ -61,28 +47,6 @@ contract ERC20BridgeableFacet {
     event Transfer(address indexed _from, address indexed _to, uint256 _value);
 
     /// -----------------------------------------------------------------------
-    /// ERC165 integration (re-uses ERC165Facet storage layout)
-    /// -----------------------------------------------------------------------
-
-    /// @notice Storage slot for ERC-165 using ERC8042 for storage location standardization
-    /// @dev Storage position determined by the keccak256 hash of the diamond storage identifier.
-    bytes32 constant ERC165_STORAGE_POSITION = keccak256("compose.erc165");
-    /// @notice ERC-165 storage layout using the ERC-8042 standard
-    /// @custom:storage-location erc8042:compose.erc165
-
-    struct ERC165Storage {
-        /// @notice Mapping of interface IDs to whether they are supported
-        mapping(bytes4 => bool) supportedInterfaces;
-    }
-
-    function getErc165Storage() internal pure returns (ERC165Storage storage s) {
-        bytes32 position = ERC165_STORAGE_POSITION;
-        assembly {
-            s.slot := position
-        }
-    }
-
-    /// -----------------------------------------------------------------------
     /// ERC20 integration (re-uses ERC20Facet storage layout)
     /// -----------------------------------------------------------------------
 
@@ -95,18 +59,15 @@ contract ERC20BridgeableFacet {
      * @custom:storage-location erc8042:compose.erc20
      */
     struct ERC20Storage {
-        string name;
-        string symbol;
-        uint8 decimals;
-        uint256 totalSupply;
         mapping(address owner => uint256 balance) balanceOf;
+        uint256 totalSupply;
     }
-
     /**
      * @notice Returns the ERC20 storage struct from the predefined diamond storage slot.
      * @dev Uses inline assembly to set the storage slot reference.
      * @return s The ERC20 storage struct reference.
      */
+
     function getERC20Storage() internal pure returns (ERC20Storage storage s) {
         bytes32 position = ERC20_STORAGE_POSITION;
         assembly {
@@ -134,9 +95,6 @@ contract ERC20BridgeableFacet {
         }
     }
 
-    /// @notice role identifier for trusted bridge actors
-    bytes32 internal constant TRUSTED_BRIDGE_ROLE = keccak256("trusted-bridge");
-
     /// @notice Cross-chain mint — callable only by an address having the `trusted-bridge` role.
     /// @param _account The account to mint tokens to.
     /// @param _value The amount to mint.
@@ -146,9 +104,9 @@ contract ERC20BridgeableFacet {
         AccessControlStorage storage acs = getAccessControlStorage();
 
         // authorize: caller must have the trusted-bridge role
-       if (!acs.hasRole[msg.sender][TRUSTED_BRIDGE_ROLE]) {
-    revert AccessControlUnauthorizedAccount(msg.sender, TRUSTED_BRIDGE_ROLE);
-}
+        if (!acs.hasRole[msg.sender]["trusted-bridge"]) {
+            revert AccessControlUnauthorizedAccount(msg.sender, "trusted-bridge");
+        }
 
         if (_account == address(0)) {
             revert ERC20InvalidReciever(address(0));
@@ -171,9 +129,9 @@ contract ERC20BridgeableFacet {
         AccessControlStorage storage acs = getAccessControlStorage();
 
         // authorize: caller must have the trusted-bridge role
-       if (!acs.hasRole[msg.sender][TRUSTED_BRIDGE_ROLE]) {
-    revert AccessControlUnauthorizedAccount(msg.sender, TRUSTED_BRIDGE_ROLE);
-}
+        if (!acs.hasRole[msg.sender]["trusted-bridge"]) {
+            revert AccessControlUnauthorizedAccount(msg.sender, "trusted-bridge");
+        }
         if (_from == address(0)) {
             revert ERC20InvalidReciever(address(0));
         }
@@ -203,25 +161,8 @@ contract ERC20BridgeableFacet {
             revert ERC20InvalidBridgeAccount(address(0));
         }
 
-        if (!acs.hasRole[_caller][TRUSTED_BRIDGE_ROLE]) {
+        if (!acs.hasRole[_caller]["trusted-bridge"]) {
             revert ERC20InvalidBridgeAccount(_caller);
         }
-    }
-
-    /// @notice Query if a contract implements an interface
-    /// @param _interfaceId The interface identifier, as specified in ERC-165
-    /// @dev This function checks if the diamond supports the given interface ID
-    /// @return `true` if the contract implements `_interfaceId` and
-    /// `_interfaceId` is not 0xffffffff, `false` otherwise
-    function supportsInterface(bytes4 _interfaceId) external view returns (bool) {
-        ERC165Storage storage erc165Storage = getErc165Storage();
-
-        // If the ERC165 interface itself is being queried, return true
-        // since this facet implements ERC165
-        if (_interfaceId == type(IERC165).interfaceId) {
-            return true;
-        }
-
-        return erc165Storage.supportedInterfaces[_interfaceId];
     }
 }

--- a/src/ERC20Bridgeable/libraries/LibERC20Bridgeable.sol
+++ b/src/ERC20Bridgeable/libraries/LibERC20Bridgeable.sol
@@ -25,7 +25,7 @@ library LibERC20Bridgeable {
     /// @param _role The role that the account does not have.
     /// @param _account The account that does not have the role.
     error AccessControlUnauthorizedAccount(address _account, bytes32 _role);
-    
+
     error ERC20InsufficientBalance(address _from, uint256 _accountBalance, uint256 _value);
 
     /// @notice Emitted when tokens are minted via a cross-chain bridge.
@@ -59,18 +59,15 @@ library LibERC20Bridgeable {
      * @custom:storage-location erc8042:compose.erc20
      */
     struct ERC20Storage {
-        string name;
-        string symbol;
-        uint8 decimals;
-        uint256 totalSupply;
         mapping(address owner => uint256 balance) balanceOf;
+        uint256 totalSupply;
     }
-
     /**
      * @notice Returns the ERC20 storage struct from the predefined diamond storage slot.
      * @dev Uses inline assembly to set the storage slot reference.
      * @return s The ERC20 storage struct reference.
      */
+
     function getERC20Storage() internal pure returns (ERC20Storage storage s) {
         bytes32 position = ERC20_STORAGE_POSITION;
         assembly {
@@ -97,9 +94,6 @@ library LibERC20Bridgeable {
             s.slot := position
         }
     }
-    /// @notice role identifier for trusted bridge actors
-
-    bytes32 internal constant TRUSTED_BRIDGE_ROLE = keccak256("trusted-bridge");
 
     /// @notice Cross-chain mint — callable only by an address having the `trusted-bridge` role.
     /// @param _account The account to mint tokens to.
@@ -110,9 +104,9 @@ library LibERC20Bridgeable {
         AccessControlStorage storage acs = getAccessControlStorage();
 
         // authorize: caller must have the trusted-bridge role
-        if (!acs.hasRole[msg.sender][TRUSTED_BRIDGE_ROLE]) {
-    revert AccessControlUnauthorizedAccount(msg.sender, TRUSTED_BRIDGE_ROLE);
-}
+        if (!acs.hasRole[msg.sender]["trusted-bridge"]) {
+            revert AccessControlUnauthorizedAccount(msg.sender, "trusted-bridge");
+        }
 
         if (_account == address(0)) {
             revert ERC20InvalidReciever(address(0));
@@ -136,9 +130,9 @@ library LibERC20Bridgeable {
         AccessControlStorage storage acs = getAccessControlStorage();
 
         // authorize: caller must have the trusted-bridge role
-        if (!acs.hasRole[msg.sender][TRUSTED_BRIDGE_ROLE]) {
-    revert AccessControlUnauthorizedAccount(msg.sender, TRUSTED_BRIDGE_ROLE);
-}
+        if (!acs.hasRole[msg.sender]["trusted-bridge"]) {
+            revert AccessControlUnauthorizedAccount(msg.sender, "trusted-bridge");
+        }
 
         if (_from == address(0)) {
             revert ERC20InvalidReciever(address(0));
@@ -168,7 +162,7 @@ library LibERC20Bridgeable {
             revert ERC20InvalidBridgeAccount(address(0));
         }
 
-        if (!acs.hasRole[_caller][TRUSTED_BRIDGE_ROLE]) {
+        if (!acs.hasRole[_caller]["trusted-bridge"]) {
             revert ERC20InvalidBridgeAccount(_caller);
         }
     }


### PR DESCRIPTION
I impemented the ERC-7802 for cross-chain Token interoperability.. Using the Openzeppelin code as a template: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/draft-ERC20Bridgeable.sol