### PR TITLE
Fix #159 : LibERC721Enumerable.sol now set token owner during mint to resolve missing ownership 

### DIFF
--- a/src/token/ERC721/ERC721Enumerable/LibERC721Enumerable.sol
+++ b/src/token/ERC721/ERC721Enumerable/LibERC721Enumerable.sol
@@ -119,6 +119,7 @@ library LibERC721 {
             revert ERC721InvalidSender(address(0));
         }
 
+        s.ownerOf[_tokenId] = _to;
         s.ownedTokensIndexOf[_tokenId] = s.ownedTokensOf[_to].length;
         s.ownedTokensOf[_to].push(_tokenId);
         s.allTokensIndexOf[_tokenId] = s.allTokens.length;


### PR DESCRIPTION
## Summary
This pull request fixes [#159] — the bug where LibERC721Enumerable.mint() did not assign ownership for newly minted tokens. Without this assignment, the token appeared non-existent (ownerOf[tokenId] == address(0)), causing transferFrom and burn to revert.

## Changes Made
- Added missing `s.ownerOf[_tokenId] = _to;` in mint() before updating enumeration arrays.
- Ensured ownership is set prior to emitting Transfer(0x0, _to, tokenId) for consistent event/state ordering.
- Verified mint now aligns with ERC-721 expected invariants and enumeration logic.