### PR TITLE
fix: correct deploy script reference in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -364,7 +364,7 @@ cast <subcommand>
 
 ```bash
 # Deploy contracts
-forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+forge script script/ERC20.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
 ```
 
 ### Help


### PR DESCRIPTION
## Summary
Fix the incorrect deploy script reference in CONTRIBUTING.md that pointed to a non-existent file.

## Changes
- Updated deploy command example from \`script/Counter.s.sol\` to \`script/ERC20.sol\` to match the actual file in the repository

## Impact
- Documentation accuracy improved
- Devs can now copy-paste the deploy command without errors