### PR TITLE
feat(AccessControl):Add AccessControl Pausable facet with dedicated library and tests

### DIFF
--- a/src/access/AccessControlPausable/AccessControlPausableFacet.sol
+++ b/src/access/AccessControlPausable/AccessControlPausableFacet.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+contract AccessControlPausableFacet {
+    /// @notice Event emitted when a role is paused.
+    /// @param _role The role that was paused.
+    /// @param _account The account that paused the role.
+    event RolePaused(bytes32 indexed _role, address indexed _account);
+
+    /// @notice Event emitted when a role is unpaused.
+    /// @param _role The role that was unpaused.
+    /// @param _account The account that unpaused the role.
+    event RoleUnpaused(bytes32 indexed _role, address indexed _account);
+
+    /// @notice Thrown when the account does not have a specific role.
+    /// @param _role The role that the account does not have.
+    /// @param _account The account that does not have the role.
+    error AccessControlUnauthorizedAccount(address _account, bytes32 _role);
+
+    /// @notice Thrown when a role is paused and an operation requiring that role is attempted.
+    /// @param _role The role that is paused.
+    error AccessControlRolePaused(bytes32 _role);
+
+    /// @notice Storage slot identifier for AccessControl (reused to access roles).
+    bytes32 constant ACCESS_CONTROL_STORAGE_POSITION = keccak256("compose.accesscontrol");
+
+    /// @notice Storage slot identifier for Pausable functionality.
+    bytes32 constant PAUSABLE_STORAGE_POSITION = keccak256("compose.accesscontrol.pausable");
+
+    /// @notice Storage struct for AccessControl (reused struct definition).
+    /// @dev Must match the struct definition in AccessControlFacet.
+    /// @custom:storage-location erc8042:compose.accesscontrol
+    struct AccessControlStorage {
+        mapping(address account => mapping(bytes32 role => bool hasRole)) hasRole;
+        mapping(bytes32 role => bytes32 adminRole) adminRole;
+    }
+
+    /// @notice Storage struct for AccessControlPausable.
+    /// @custom:storage-location erc8042:compose.accesscontrol.pausable
+    struct AccessControlPausableStorage {
+        mapping(bytes32 role => bool paused) pausedRoles;
+    }
+
+    /// @notice Returns the storage for AccessControl.
+    /// @return s The AccessControl storage struct.
+    function getAccessControlStorage() internal pure returns (AccessControlStorage storage s) {
+        bytes32 position = ACCESS_CONTROL_STORAGE_POSITION;
+        assembly {
+            s.slot := position
+        }
+    }
+
+    /// @notice Returns the storage for AccessControlPausable.
+    /// @return s The AccessControlPausable storage struct.
+    function getStorage() internal pure returns (AccessControlPausableStorage storage s) {
+        bytes32 position = PAUSABLE_STORAGE_POSITION;
+        assembly {
+            s.slot := position
+        }
+    }
+
+    /// @notice Returns if a role is paused.
+    /// @param _role The role to check.
+    /// @return True if the role is paused, false otherwise.
+    function isRolePaused(bytes32 _role) external view returns (bool) {
+        return getStorage().pausedRoles[_role];
+    }
+
+    /// @notice Temporarily disables a role, preventing all accounts from using it.
+    /// @param _role The role to pause.
+    /// @dev Only the admin of the role can pause it.
+    ///      Emits a {RolePaused} event.
+    /// @custom:error AccessControlUnauthorizedAccount If the caller is not the admin of the role.
+    function pauseRole(bytes32 _role) external {
+        AccessControlStorage storage acs = getAccessControlStorage();
+        AccessControlPausableStorage storage s = getStorage();
+
+        // Get the admin role for this role
+        bytes32 adminRole = acs.adminRole[_role];
+
+        // Check if the caller is the admin of the role.
+        if (!acs.hasRole[msg.sender][adminRole]) {
+            revert AccessControlUnauthorizedAccount(msg.sender, adminRole);
+        }
+
+        // Pause the role
+        s.pausedRoles[_role] = true;
+        emit RolePaused(_role, msg.sender);
+    }
+
+    /// @notice Re-enables a role that was previously paused.
+    /// @param _role The role to unpause.
+    /// @dev Only the admin of the role can unpause it.
+    ///      Emits a {RoleUnpaused} event.
+    /// @custom:error AccessControlUnauthorizedAccount If the caller is not the admin of the role.
+    function unpauseRole(bytes32 _role) external {
+        AccessControlStorage storage acs = getAccessControlStorage();
+        AccessControlPausableStorage storage s = getStorage();
+
+        // Get the admin role for this role
+        bytes32 adminRole = acs.adminRole[_role];
+
+        // Check if the caller is the admin of the role.
+        if (!acs.hasRole[msg.sender][adminRole]) {
+            revert AccessControlUnauthorizedAccount(msg.sender, adminRole);
+        }
+
+        // Unpause the role
+        s.pausedRoles[_role] = false;
+        emit RoleUnpaused(_role, msg.sender);
+    }
+
+    /// @notice Checks if an account has a role and if the role is not paused.
+    /// @param _role The role to check.
+    /// @param _account The account to check the role for.
+    /// @custom:error AccessControlUnauthorizedAccount If the account does not have the role.
+    /// @custom:error AccessControlRolePaused If the role is paused.
+    function requireRoleNotPaused(bytes32 _role, address _account) external view {
+        AccessControlStorage storage acs = getAccessControlStorage();
+        AccessControlPausableStorage storage s = getStorage();
+
+        // First check if the account has the role
+        if (!acs.hasRole[_account][_role]) {
+            revert AccessControlUnauthorizedAccount(_account, _role);
+        }
+
+        // Then check if the role is paused
+        if (s.pausedRoles[_role]) {
+            revert AccessControlRolePaused(_role);
+        }
+    }
+}

--- a/src/access/AccessControlPausable/LibAccessControlPausable.sol
+++ b/src/access/AccessControlPausable/LibAccessControlPausable.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+library LibAccessControlPausable {
+    /// @notice Event emitted when a role is paused.
+    /// @param _role The role that was paused.
+    /// @param _account The account that paused the role.
+    event RolePaused(bytes32 indexed _role, address indexed _account);
+
+    /// @notice Event emitted when a role is unpaused.
+    /// @param _role The role that was unpaused.
+    /// @param _account The account that unpaused the role.
+    event RoleUnpaused(bytes32 indexed _role, address indexed _account);
+
+    /// @notice Thrown when the account does not have a specific role.
+    /// @param _role The role that the account does not have.
+    /// @param _account The account that does not have the role.
+    error AccessControlUnauthorizedAccount(address _account, bytes32 _role);
+
+    /// @notice Thrown when a role is paused and an operation requiring that role is attempted.
+    /// @param _role The role that is paused.
+    error AccessControlRolePaused(bytes32 _role);
+
+    /// @notice Storage slot identifier for AccessControl (reused to access roles).
+    bytes32 constant ACCESS_CONTROL_STORAGE_POSITION = keccak256("compose.accesscontrol");
+
+    /// @notice Storage slot identifier for Pausable functionality.
+    bytes32 constant PAUSABLE_STORAGE_POSITION = keccak256("compose.accesscontrol.pausable");
+
+    /// @notice Storage struct for AccessControl (reused struct definition).
+    /// @dev Must match the struct definition in AccessControlFacet.
+    /// @custom:storage-location erc8042:compose.accesscontrol
+    struct AccessControlStorage {
+        mapping(address account => mapping(bytes32 role => bool hasRole)) hasRole;
+        mapping(bytes32 role => bytes32 adminRole) adminRole;
+    }
+
+    /// @notice Storage struct for AccessControlPausable.
+    /// @custom:storage-location erc8042:compose.accesscontrol.pausable
+    struct AccessControlPausableStorage {
+        mapping(bytes32 role => bool paused) pausedRoles;
+    }
+
+    /// @notice Returns the storage for AccessControl.
+    /// @return s The AccessControl storage struct.
+    function getAccessControlStorage() internal pure returns (AccessControlStorage storage s) {
+        bytes32 position = ACCESS_CONTROL_STORAGE_POSITION;
+        assembly {
+            s.slot := position
+        }
+    }
+
+    /// @notice Returns the storage for AccessControlPausable.
+    /// @return s The AccessControlPausable storage struct.
+    function getStorage() internal pure returns (AccessControlPausableStorage storage s) {
+        bytes32 position = PAUSABLE_STORAGE_POSITION;
+        assembly {
+            s.slot := position
+        }
+    }
+
+    /// @notice function to check if a role is paused.
+    /// @param _role The role to check.
+    /// @return True if the role is paused, false otherwise.
+    function isRolePaused(bytes32 _role) internal view returns (bool) {
+        AccessControlPausableStorage storage s = getStorage();
+        return s.pausedRoles[_role];
+    }
+
+    /// @notice function to pause a role.
+    /// @param _role The role to pause.
+    function pauseRole(bytes32 _role) internal {
+        AccessControlPausableStorage storage s = getStorage();
+        s.pausedRoles[_role] = true;
+        emit RolePaused(_role, msg.sender);
+    }
+
+    /// @notice function to unpause a role.
+    /// @param _role The role to unpause.
+    function unpauseRole(bytes32 _role) internal {
+        AccessControlPausableStorage storage s = getStorage();
+        s.pausedRoles[_role] = false;
+        emit RoleUnpaused(_role, msg.sender);
+    }
+
+    /// @notice function to check if an account has a role and if the role is not paused.
+    /// @param _role The role to check.
+    /// @param _account The account to check the role for.
+    /// @custom:error AccessControlUnauthorizedAccount If the account does not have the role.
+    /// @custom:error AccessControlRolePaused If the role is paused.
+    function requireRoleNotPaused(bytes32 _role, address _account) internal view {
+        AccessControlStorage storage acs = getAccessControlStorage();
+        AccessControlPausableStorage storage s = getStorage();
+
+        // First check if the account has the role
+        if (!acs.hasRole[_account][_role]) {
+            revert AccessControlUnauthorizedAccount(_account, _role);
+        }
+
+        // Then check if the role is paused
+        if (s.pausedRoles[_role]) {
+            revert AccessControlRolePaused(_role);
+        }
+    }
+}

--- a/test/access/AccessControlPausable/AccessControlPausableFacet.t.sol
+++ b/test/access/AccessControlPausable/AccessControlPausableFacet.t.sol
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {AccessControlPausableFacet} from "../../../src/access/AccessControlPausable/AccessControlPausableFacet.sol";
+import {AccessControlFacet} from "../../../src/access/AccessControl/AccessControlFacet.sol";
+import {AccessControlPausableFacetHarness} from "./harnesses/AccessControlPausableFacetHarness.sol";
+import {AccessControlFacetHarness} from "../AccessControl/harnesses/AccessControlFacetHarness.sol";
+
+contract AccessControlPausableFacetTest is Test {
+    AccessControlPausableFacetHarness public pausableFacet;
+    AccessControlFacetHarness public accessControl;
+
+    // Test addresses
+    address ADMIN = makeAddr("admin");
+    address ALICE = makeAddr("alice");
+    address BOB = makeAddr("bob");
+    address CHARLIE = makeAddr("charlie");
+
+    // Test roles
+    bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+    bytes32 constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    // Events
+    event RolePaused(bytes32 indexed role, address indexed account);
+    event RoleUnpaused(bytes32 indexed role, address indexed account);
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+
+    function setUp() public {
+        // Initialize AccessControl first (shared storage)
+        accessControl = new AccessControlFacetHarness();
+        accessControl.initialize(ADMIN);
+
+        // Initialize PausableFacet (uses same AccessControl storage)
+        pausableFacet = new AccessControlPausableFacetHarness();
+        pausableFacet.initialize(ADMIN);
+    }
+
+    // ============================================
+    // IsRolePaused Tests
+    // ============================================
+
+    function test_IsRolePaused_ReturnsFalseByDefault() public view {
+        assertFalse(pausableFacet.isRolePaused(MINTER_ROLE));
+    }
+
+    function test_IsRolePaused_ReturnsTrueWhenPaused() public {
+        // Grant role first
+        vm.prank(ADMIN);
+        accessControl.grantRole(MINTER_ROLE, ALICE);
+
+        // Pause the role
+        vm.prank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+
+        assertTrue(pausableFacet.isRolePaused(MINTER_ROLE));
+    }
+
+    // ============================================
+    // PauseRole Tests
+    // ============================================
+
+    function test_PauseRole_SucceedsWhenCallerIsAdmin() public {
+        vm.expectEmit(true, true, false, true);
+        emit RolePaused(MINTER_ROLE, ADMIN);
+
+        vm.prank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+
+        assertTrue(pausableFacet.isRolePaused(MINTER_ROLE));
+        assertTrue(pausableFacet.getStoragePaused(MINTER_ROLE));
+    }
+
+    function test_PauseRole_CanBeCalledMultipleTimes() public {
+        vm.startPrank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+        pausableFacet.pauseRole(MINTER_ROLE);
+        pausableFacet.pauseRole(MINTER_ROLE);
+        vm.stopPrank();
+
+        assertTrue(pausableFacet.isRolePaused(MINTER_ROLE));
+    }
+
+    function test_RevertWhen_PauseRole_CallerIsNotAdmin() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControlPausableFacet.AccessControlUnauthorizedAccount.selector, ALICE, DEFAULT_ADMIN_ROLE
+            )
+        );
+        vm.prank(ALICE);
+        pausableFacet.pauseRole(MINTER_ROLE);
+    }
+
+    function test_PauseRole_MultipleRolesCanBePaused() public {
+        vm.startPrank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+        pausableFacet.pauseRole(PAUSER_ROLE);
+        vm.stopPrank();
+
+        assertTrue(pausableFacet.isRolePaused(MINTER_ROLE));
+        assertTrue(pausableFacet.isRolePaused(PAUSER_ROLE));
+    }
+
+    // ============================================
+    // UnpauseRole Tests
+    // ============================================
+
+    function test_UnpauseRole_SucceedsWhenCallerIsAdmin() public {
+        // First pause
+        vm.prank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+        assertTrue(pausableFacet.isRolePaused(MINTER_ROLE));
+
+        // Then unpause
+        vm.expectEmit(true, true, false, true);
+        emit RoleUnpaused(MINTER_ROLE, ADMIN);
+
+        vm.prank(ADMIN);
+        pausableFacet.unpauseRole(MINTER_ROLE);
+
+        assertFalse(pausableFacet.isRolePaused(MINTER_ROLE));
+    }
+
+    function test_UnpauseRole_CanBeCalledMultipleTimes() public {
+        vm.prank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+
+        vm.startPrank(ADMIN);
+        pausableFacet.unpauseRole(MINTER_ROLE);
+        pausableFacet.unpauseRole(MINTER_ROLE);
+        pausableFacet.unpauseRole(MINTER_ROLE);
+        vm.stopPrank();
+
+        assertFalse(pausableFacet.isRolePaused(MINTER_ROLE));
+    }
+
+    function test_RevertWhen_UnpauseRole_CallerIsNotAdmin() public {
+        // First pause with admin
+        vm.prank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+
+        // Then try to unpause without admin role
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControlPausableFacet.AccessControlUnauthorizedAccount.selector, ALICE, DEFAULT_ADMIN_ROLE
+            )
+        );
+        vm.prank(ALICE);
+        pausableFacet.unpauseRole(MINTER_ROLE);
+    }
+
+    function test_PauseUnpauseCycle_MultipleCycles() public {
+        vm.startPrank(ADMIN);
+
+        // First cycle
+        pausableFacet.pauseRole(MINTER_ROLE);
+        assertTrue(pausableFacet.isRolePaused(MINTER_ROLE));
+
+        pausableFacet.unpauseRole(MINTER_ROLE);
+        assertFalse(pausableFacet.isRolePaused(MINTER_ROLE));
+
+        // Second cycle
+        pausableFacet.pauseRole(MINTER_ROLE);
+        assertTrue(pausableFacet.isRolePaused(MINTER_ROLE));
+
+        pausableFacet.unpauseRole(MINTER_ROLE);
+        assertFalse(pausableFacet.isRolePaused(MINTER_ROLE));
+
+        vm.stopPrank();
+    }
+
+    // ============================================
+    // RequireRoleNotPaused Tests
+    // ============================================
+
+    function test_RequireRoleNotPaused_PassesWhenRoleNotPaused() public {
+        // Grant role to Alice using harness (direct storage manipulation)
+        pausableFacet.forceGrantRole(MINTER_ROLE, ALICE);
+
+        // Should pass (role exists and not paused)
+        pausableFacet.requireRoleNotPaused(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevertWhen_RequireRoleNotPaused_RoleIsPaused() public {
+        // Grant role to Alice using harness
+        pausableFacet.forceGrantRole(MINTER_ROLE, ALICE);
+
+        // Pause the role
+        vm.prank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+
+        // Should revert
+        vm.expectRevert(
+            abi.encodeWithSelector(AccessControlPausableFacet.AccessControlRolePaused.selector, MINTER_ROLE)
+        );
+        pausableFacet.requireRoleNotPaused(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevertWhen_RequireRoleNotPaused_AccountDoesNotHaveRole() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AccessControlPausableFacet.AccessControlUnauthorizedAccount.selector, ALICE, MINTER_ROLE
+            )
+        );
+        pausableFacet.requireRoleNotPaused(MINTER_ROLE, ALICE);
+    }
+
+    function test_RequireRoleNotPaused_AfterUnpause() public {
+        // Grant role to Alice using harness
+        pausableFacet.forceGrantRole(MINTER_ROLE, ALICE);
+
+        // Pause
+        vm.prank(ADMIN);
+        pausableFacet.pauseRole(MINTER_ROLE);
+
+        // Unpause
+        vm.prank(ADMIN);
+        pausableFacet.unpauseRole(MINTER_ROLE);
+
+        // Should pass now
+        pausableFacet.requireRoleNotPaused(MINTER_ROLE, ALICE);
+    }
+
+    // ============================================
+    // Custom Admin Role Tests
+    // ============================================
+
+    function test_PauseRole_WithCustomRoleAdmin() public {
+        // Set up custom admin using harness
+        pausableFacet.forceGrantRole(PAUSER_ROLE, BOB);
+        pausableFacet.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+
+        // Bob can pause MINTER_ROLE
+        vm.expectEmit(true, true, false, true);
+        emit RolePaused(MINTER_ROLE, BOB);
+
+        vm.prank(BOB);
+        pausableFacet.pauseRole(MINTER_ROLE);
+
+        assertTrue(pausableFacet.isRolePaused(MINTER_ROLE));
+    }
+
+    function test_UnpauseRole_WithCustomRoleAdmin() public {
+        // Set up custom admin using harness
+        pausableFacet.forceGrantRole(PAUSER_ROLE, BOB);
+        pausableFacet.forceSetRoleAdmin(MINTER_ROLE, PAUSER_ROLE);
+
+        // Pause with Bob
+        vm.prank(BOB);
+        pausableFacet.pauseRole(MINTER_ROLE);
+
+        // Unpause with Bob
+        vm.expectEmit(true, true, false, true);
+        emit RoleUnpaused(MINTER_ROLE, BOB);
+
+        vm.prank(BOB);
+        pausableFacet.unpauseRole(MINTER_ROLE);
+
+        assertFalse(pausableFacet.isRolePaused(MINTER_ROLE));
+    }
+}

--- a/test/access/AccessControlPausable/LibAccessControlPausable.t.sol
+++ b/test/access/AccessControlPausable/LibAccessControlPausable.t.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {LibAccessControlPausable} from "../../../src/access/AccessControlPausable/LibAccessControlPausable.sol";
+import {LibAccessControl} from "../../../src/access/AccessControl/LibAccessControl.sol";
+import {LibAccessControlPausableHarness} from "./harnesses/LibAccessControlPausableHarness.sol";
+import {LibAccessControlHarness} from "../AccessControl/harnesses/LibAccessControlHarness.sol";
+
+contract LibAccessControlPausableTest is Test {
+    LibAccessControlPausableHarness public harness;
+    LibAccessControlHarness public accessControl;
+
+    // Test addresses
+    address ADMIN = makeAddr("admin");
+    address ALICE = makeAddr("alice");
+    address BOB = makeAddr("bob");
+
+    // Test roles
+    bytes32 constant DEFAULT_ADMIN_ROLE = 0x00;
+    bytes32 constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    // Events
+    event RolePaused(bytes32 indexed role, address indexed account);
+    event RoleUnpaused(bytes32 indexed role, address indexed account);
+
+    function setUp() public {
+        // Initialize AccessControl first (shared storage)
+        accessControl = new LibAccessControlHarness();
+        accessControl.initialize(ADMIN);
+
+        // Initialize Pausable harness (uses same AccessControl storage)
+        harness = new LibAccessControlPausableHarness();
+        harness.initialize(ADMIN);
+    }
+
+    // ============================================
+    // IsRolePaused Tests
+    // ============================================
+
+    function test_IsRolePaused_ReturnsFalseByDefault() public view {
+        assertFalse(harness.isRolePaused(MINTER_ROLE));
+    }
+
+    function test_IsRolePaused_ReturnsTrueWhenPaused() public {
+        vm.prank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+
+        assertTrue(harness.isRolePaused(MINTER_ROLE));
+        assertTrue(harness.getStoragePaused(MINTER_ROLE));
+    }
+
+    // ============================================
+    // PauseRole Tests
+    // ============================================
+
+    function test_PauseRole_EmitsRolePausedEvent() public {
+        vm.expectEmit(true, true, false, true);
+        emit RolePaused(MINTER_ROLE, address(harness));
+
+        vm.prank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+    }
+
+    function test_PauseRole_CanBeCalledMultipleTimes() public {
+        vm.startPrank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+        harness.pauseRole(MINTER_ROLE);
+        harness.pauseRole(MINTER_ROLE);
+        vm.stopPrank();
+
+        assertTrue(harness.isRolePaused(MINTER_ROLE));
+    }
+
+    // ============================================
+    // UnpauseRole Tests
+    // ============================================
+
+    function test_UnpauseRole_EmitsRoleUnpausedEvent() public {
+        vm.prank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+
+        vm.expectEmit(true, true, false, true);
+        emit RoleUnpaused(MINTER_ROLE, address(harness));
+
+        vm.prank(address(harness));
+        harness.unpauseRole(MINTER_ROLE);
+    }
+
+    function test_UnpauseRole_CanBeCalledMultipleTimes() public {
+        vm.prank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+
+        vm.startPrank(address(harness));
+        harness.unpauseRole(MINTER_ROLE);
+        harness.unpauseRole(MINTER_ROLE);
+        harness.unpauseRole(MINTER_ROLE);
+        vm.stopPrank();
+
+        assertFalse(harness.isRolePaused(MINTER_ROLE));
+    }
+
+    function test_PauseUnpauseCycle_MultipleCycles() public {
+        vm.startPrank(address(harness));
+
+        // First cycle
+        harness.pauseRole(MINTER_ROLE);
+        assertTrue(harness.isRolePaused(MINTER_ROLE));
+
+        harness.unpauseRole(MINTER_ROLE);
+        assertFalse(harness.isRolePaused(MINTER_ROLE));
+
+        // Second cycle
+        harness.pauseRole(MINTER_ROLE);
+        assertTrue(harness.isRolePaused(MINTER_ROLE));
+
+        harness.unpauseRole(MINTER_ROLE);
+        assertFalse(harness.isRolePaused(MINTER_ROLE));
+
+        vm.stopPrank();
+    }
+
+    // ============================================
+    // RequireRoleNotPaused Tests
+    // ============================================
+
+    function test_RequireRoleNotPaused_PassesWhenRoleNotPaused() public {
+        // Grant role to Alice
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+
+        // Should pass (role exists and not paused)
+        harness.requireRoleNotPaused(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevertWhen_RequireRoleNotPaused_RoleIsPaused() public {
+        // Grant role to Alice
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+
+        // Pause the role
+        vm.prank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+
+        // Should revert
+        vm.expectRevert(abi.encodeWithSelector(LibAccessControlPausable.AccessControlRolePaused.selector, MINTER_ROLE));
+        harness.requireRoleNotPaused(MINTER_ROLE, ALICE);
+    }
+
+    function test_RevertWhen_RequireRoleNotPaused_AccountDoesNotHaveRole() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibAccessControlPausable.AccessControlUnauthorizedAccount.selector, ALICE, MINTER_ROLE
+            )
+        );
+        harness.requireRoleNotPaused(MINTER_ROLE, ALICE);
+    }
+
+    function test_RequireRoleNotPaused_AfterUnpause() public {
+        // Grant role to Alice
+        harness.forceGrantRole(MINTER_ROLE, ALICE);
+
+        // Pause
+        vm.prank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+
+        // Unpause
+        vm.prank(address(harness));
+        harness.unpauseRole(MINTER_ROLE);
+
+        // Should pass now
+        harness.requireRoleNotPaused(MINTER_ROLE, ALICE);
+    }
+
+    function test_PauseRole_MultipleRolesCanBePaused() public {
+        vm.startPrank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+        harness.pauseRole(PAUSER_ROLE);
+        vm.stopPrank();
+
+        assertTrue(harness.isRolePaused(MINTER_ROLE));
+        assertTrue(harness.isRolePaused(PAUSER_ROLE));
+    }
+
+    // ============================================
+    // Storage Consistency Tests
+    // ============================================
+
+    function test_StorageConsistency_PauseRole() public {
+        vm.prank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+
+        assertTrue(harness.isRolePaused(MINTER_ROLE));
+        assertTrue(harness.getStoragePaused(MINTER_ROLE));
+    }
+
+    function test_StorageConsistency_UnpauseRole() public {
+        vm.startPrank(address(harness));
+        harness.pauseRole(MINTER_ROLE);
+        assertTrue(harness.getStoragePaused(MINTER_ROLE));
+
+        harness.unpauseRole(MINTER_ROLE);
+        assertFalse(harness.getStoragePaused(MINTER_ROLE));
+        vm.stopPrank();
+    }
+
+    // ============================================
+    // Fuzz Tests
+    // ============================================
+
+    function testFuzz_PauseUnpauseCycle_ConsistentState(bytes32 role) public {
+        vm.startPrank(address(harness));
+
+        // Pause
+        harness.pauseRole(role);
+        assertTrue(harness.isRolePaused(role));
+
+        // Unpause
+        harness.unpauseRole(role);
+        assertFalse(harness.isRolePaused(role));
+
+        vm.stopPrank();
+    }
+}

--- a/test/access/AccessControlPausable/harnesses/AccessControlPausableFacetHarness.sol
+++ b/test/access/AccessControlPausable/harnesses/AccessControlPausableFacetHarness.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {AccessControlPausableFacet} from "../../../../src/access/AccessControlPausable/AccessControlPausableFacet.sol";
+
+/// @title AccessControlPausableFacet Test Harness
+/// @notice Extends AccessControlPausableFacet with initialization and test-specific functions
+contract AccessControlPausableFacetHarness is AccessControlPausableFacet {
+    /// @notice Initialize the DEFAULT_ADMIN_ROLE for testing
+    /// @dev This function is only for testing purposes
+    function initialize(address _admin) external {
+        AccessControlStorage storage acs = getAccessControlStorage();
+        bytes32 DEFAULT_ADMIN_ROLE = 0x00;
+        acs.hasRole[_admin][DEFAULT_ADMIN_ROLE] = true;
+    }
+
+    /// @notice Force grant a role without any checks (for testing edge cases)
+    /// @dev This bypasses all access control for testing purposes
+    function forceGrantRole(bytes32 _role, address _account) external {
+        AccessControlStorage storage acs = getAccessControlStorage();
+        acs.hasRole[_account][_role] = true;
+    }
+
+    /// @notice Force set the admin role for a role without any checks
+    /// @dev This bypasses all access control for testing purposes
+    function forceSetRoleAdmin(bytes32 _role, bytes32 _adminRole) external {
+        AccessControlStorage storage acs = getAccessControlStorage();
+        acs.adminRole[_role] = _adminRole;
+    }
+
+    /// @notice Get the raw storage pausedRoles value (for testing storage consistency)
+    function getStoragePaused(bytes32 _role) external view returns (bool) {
+        return getStorage().pausedRoles[_role];
+    }
+}

--- a/test/access/AccessControlPausable/harnesses/LibAccessControlPausableHarness.sol
+++ b/test/access/AccessControlPausable/harnesses/LibAccessControlPausableHarness.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {LibAccessControlPausable} from "../../../../src/access/AccessControlPausable/LibAccessControlPausable.sol";
+
+/// @title LibAccessControlPausable Test Harness
+/// @notice Exposes internal LibAccessControlPausable functions as external for testing
+contract LibAccessControlPausableHarness {
+    /// @notice Initialize roles for testing
+    /// @param _account The account to grant the default admin role to
+    function initialize(address _account) external {
+        LibAccessControlPausable.AccessControlStorage storage acs = LibAccessControlPausable.getAccessControlStorage();
+        bytes32 DEFAULT_ADMIN_ROLE = 0x00;
+        acs.hasRole[_account][DEFAULT_ADMIN_ROLE] = true;
+    }
+
+    /// @notice Check if a role is paused
+    function isRolePaused(bytes32 _role) external view returns (bool) {
+        return LibAccessControlPausable.isRolePaused(_role);
+    }
+
+    /// @notice Pause a role
+    function pauseRole(bytes32 _role) external {
+        LibAccessControlPausable.pauseRole(_role);
+    }
+
+    /// @notice Unpause a role
+    function unpauseRole(bytes32 _role) external {
+        LibAccessControlPausable.unpauseRole(_role);
+    }
+
+    /// @notice Require that a role is not paused
+    function requireRoleNotPaused(bytes32 _role, address _account) external view {
+        LibAccessControlPausable.requireRoleNotPaused(_role, _account);
+    }
+
+    /// @notice Force grant a role without any checks (for testing edge cases)
+    function forceGrantRole(bytes32 _role, address _account) external {
+        LibAccessControlPausable.AccessControlStorage storage acs = LibAccessControlPausable.getAccessControlStorage();
+        acs.hasRole[_account][_role] = true;
+    }
+
+    /// @notice Force set the admin role without checks (for testing edge cases)
+    function forceSetRoleAdmin(bytes32 _role, bytes32 _adminRole) external {
+        LibAccessControlPausable.AccessControlStorage storage acs = LibAccessControlPausable.getAccessControlStorage();
+        acs.adminRole[_role] = _adminRole;
+    }
+
+    /// @notice Get the raw storage pausedRoles value (for testing storage consistency)
+    function getStoragePaused(bytes32 _role) external view returns (bool) {
+        return LibAccessControlPausable.getStorage().pausedRoles[_role];
+    }
+}


### PR DESCRIPTION
## Summary
- Add pausable extension as its own diamond facet with dedicated storage helpers and harnesses.
- Cover the facet and library with positive, negative, and storage-consistency Forge tests.

## Changes Made
- Implement `AccessControlPausableFacet` and` LibAccessControlPausable` using isolated diamond storage.
- Add facet and library harness contracts for test-only setup and raw storage inspection.
- Create comprehensive forge test suites for the facet and library, including fuzzing and event checks.

## Checklist

Before submitting this PR, please ensure:

- [x] **Code follows the Solidity feature ban** - No inheritance, constructors, modifiers, public/private variables, external library functions, `using for` directives, or `selfdestruct`

- [x] **Code follows Design Principles** - Readable, uses diamond storage, favors composition over inheritance

- [x] **Code matches the codebase style** - Consistent formatting, documentation, and patterns (e.g. ERC20Facet.sol)

- [x] **Code is formatted with `forge fmt`**

- [x] **Tests are included** - All new functionality has comprehensive tests

- [x] **All tests pass** - Run `forge test` and ensure everything works

- [ ] **Documentation updated** - If applicable, update relevant documentation

## Additional Notes
- Harnesses expose direct storage access strictly for testing to verify library helpers stay in sync with raw diamond storage.
