### PR TITLE
test added for LibNonReentrancy

### DIFF
--- a/src/libraries/LibNonReentrancy.sol
+++ b/src/libraries/LibNonReentrancy.sol
@@ -32,7 +32,9 @@ library LibNonReentrancy {
         bytes32 position = NON_REENTRANT_SLOT;
         assembly ("memory-safe") {
             if tload(position) {
-                mstore(0x00, 0x43a0d067)
+                // Store the selector for "Reentrancy()" (0xab143c06) at the beginning of memory.
+                // We shift left by 224 bits (256 - 32) to left-align the 4-byte selector in the 32-byte slot.
+                mstore(0x00, shl(224, 0xab143c06))
                 revert(0x00, 0x04)
             }
             tstore(position, 1)

--- a/test/libraries/LibNonReentrancy.t.sol
+++ b/test/libraries/LibNonReentrancy.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {LibNonReentrancy} from "src/libraries/LibNonReentrancy.sol";
+import {NonReentrantHarness} from "test/libraries/harnesses/LibNonReentrancyHarness.sol";
+
+contract LibNonReentrancyTest is Test {
+    NonReentrantHarness internal harness;
+
+    function setUp() public {
+        harness = new NonReentrantHarness();
+    }
+
+    function test_GuardedIncrement_IncrementsCounter() public {
+        harness.guardedIncrement();
+        assertEq(harness.counter(), 1);
+    }
+
+    function test_GuardedIncrement_AllowsSequentialCalls() public {
+        harness.guardedIncrement();
+        harness.guardedIncrement();
+        assertEq(harness.counter(), 2);
+    }
+
+    function test_RevertWhen_ReenteringFunction() public {
+        vm.expectRevert(LibNonReentrancy.Reentrancy.selector);
+        harness.guardedIncrementAndReenter();
+    }
+
+    function test_GuardResetsAfterRevert() public {
+        vm.expectRevert(NonReentrantHarness.ForcedFailure.selector);
+        harness.guardedIncrementAndForceRevert();
+
+        harness.guardedIncrement();
+        assertEq(harness.counter(), 1);
+    }
+}

--- a/test/libraries/harnesses/LibNonReentrancyHarness.sol
+++ b/test/libraries/harnesses/LibNonReentrancyHarness.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+import {LibNonReentrancy} from "src/libraries/LibNonReentrancy.sol";
+
+contract NonReentrantHarness {
+    error ForcedFailure();
+
+    uint256 public counter;
+
+    function guardedIncrement() public {
+        LibNonReentrancy.enter();
+        counter++;
+        LibNonReentrancy.exit();
+    }
+
+    function guardedIncrementAndReenter() external {
+        LibNonReentrancy.enter();
+        counter++;
+
+        this.guardedIncrement();
+
+        LibNonReentrancy.exit();
+    }
+
+    function guardedIncrementAndForceRevert() external {
+        LibNonReentrancy.enter();
+        counter++;
+        revert ForcedFailure();
+    }
+}

--- a/test/token/ERC6909/ERC6909/ERC6909Facet.t.sol
+++ b/test/token/ERC6909/ERC6909/ERC6909Facet.t.sol
@@ -41,6 +41,7 @@ contract ERC6909FacetTest is Test {
     }
 
     function testFuzz_Mint(address caller, address to, uint256 id, uint256 amount) external {
+        vm.assume(to != address(0));
         vm.expectEmit();
         emit ERC6909Facet.Transfer(caller, address(0), to, id, amount);
 


### PR DESCRIPTION
## Summary
Added Tests for `LibNonReentrancy`  and took coverage to 100%

## Changes Made
-  New File Made `LibNonReentrancyHarness.sol` and  `LibNonReentrancy.t.sol`
- Improved Revert on `src/libraries/LibNonReentrancy.sol`
- Added `vm.assume(to != address(0));` in `testFuzz_Mint` file : `test/token/ERC6909/ERC6909/ERC6909Facet.t.sol:ERC6909FacetTest` now all test are passing earlier it was failing

## Checklist

Before submitting this PR, please ensure:

- [x] **Code follows the Solidity feature ban** - No inheritance, constructors, modifiers, public/private variables, external library functions, `using for` directives, or `selfdestruct`

- [x] **Code follows Design Principles** - Readable, uses diamond storage, favors composition over inheritance

- [x] **Code matches the codebase style** - Consistent formatting, documentation, and patterns (e.g. ERC20Facet.sol)

- [x] **Code is formatted with `forge fmt`**

- [x] **Existing tests pass** - Run tests to be sure existing tests pass.

- [ ] **New tests are optional** - If you don't provide tests for new functionality or changes then please [create a new issue](https://github.com/Perfect-Abstractions/Compose/issues/new/choose) so this can be assigned to someone.

- [x] **All tests pass** - Run `forge test` and ensure everything works

- [ ] **Documentation updated** - If applicable, update relevant documentation
#216 

