### PR TITLE
fix: add braces to one-line if statements in ERC721EnumerableFacet

### DIFF
--- a/src/token/ERC721/ERC721Enumerable/ERC721EnumerableFacet.sol
+++ b/src/token/ERC721/ERC721Enumerable/ERC721EnumerableFacet.sol
@@ -328,7 +328,9 @@ contract ERC721EnumerableFacet {
                     revert ERC721InvalidReceiver(_to);
                 }
             } catch (bytes memory reason) {
-                if (reason.length == 0) revert ERC721InvalidReceiver(_to);
+                if (reason.length == 0) {
+                    revert ERC721InvalidReceiver(_to);
+                }
                 assembly ("memory-safe") {
                     revert(add(reason, 0x20), mload(reason))
                 }
@@ -351,7 +353,9 @@ contract ERC721EnumerableFacet {
                     revert ERC721InvalidReceiver(_to);
                 }
             } catch (bytes memory reason) {
-                if (reason.length == 0) revert ERC721InvalidReceiver(_to);
+                if (reason.length == 0) {
+                    revert ERC721InvalidReceiver(_to);
+                }
                 assembly ("memory-safe") {
                     revert(add(reason, 0x20), mload(reason))
                 }


### PR DESCRIPTION
Fix style guide violation by adding braces around one-line if statements that call revert. This ensures compliance with Compose's coding standards which require all if statements to use braces.

Fixes two instances in safeTransferFrom functions (lines 331 and 354).

## Summary

This PR fixes a style guide violation in `ERC721EnumerableFacet.sol` where two one-line if statements were missing braces around their revert calls. According to Compose's style guide (STYLE.md and banned-solidity-features.mdx), all if statements must use braces, even for single-line statements.

## Changes Made

- **Fixed line 331**: Added braces around `if (reason.length == 0) revert ERC721InvalidReceiver(_to);` in the `safeTransferFrom(address, address, uint256)` function
- **Fixed line 354**: Added braces around `if (reason.length == 0) revert ERC721InvalidReceiver(_to);` in the `safeTransferFrom(address, address, uint256, bytes)` function
- **Code formatting**: Ran `forge fmt` to ensure proper formatting

Both instances were in the error handling catch blocks of the safe transfer functions, where empty revert reasons are checked before propagating the original revert reason.

## Checklist

- [x] **Code follows the Solidity feature ban** - No inheritance, constructors, modifiers, public/private variables, external library functions, `using for` directives, or `selfdestruct`

- [x] **Code follows Design Principles** - Readable, uses diamond storage, favors composition over inheritance

- [x] **Code matches the codebase style** - Consistent formatting, documentation, and patterns (e.g. ERC20Facet.sol)

- [x] **Code is formatted with `forge fmt`** - ✅ Formatted with `forge fmt`

- [x] **Existing tests pass** - ✅ All 38 tests in `ERC721EnumerableFacet.t.sol` pass

- [x] **New tests are optional** - N/A - This is a style fix, no functional changes

- [x] **All tests pass** - ✅ Verified with `forge test --match-path "test/token/ERC721/ERC721Enumerable/ERC721EnumerableFacet.t.sol"` (38 tests passed)

- [x] **Documentation updated** - N/A - No documentation changes needed for style fixes


## Additional Notes

- This is a pure style fix with no functional changes
- The fix ensures compliance with the style guide rule: "No single if statements without braces" (from `banned-solidity-features.mdx`)
- All existing tests continue to pass, confirming no behavioral changes
- The change improves code consistency with the rest of the codebase