### PR TITLE
[Testing] : Gas Cost Benchmarks for Diamond events

### DIFF
--- a/test/benchmark/DiamondEventStrategies.t.sol
+++ b/test/benchmark/DiamondEventStrategies.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.30;
 import {Test} from "forge-std/Test.sol";
 import "../../src/diamond/DiamondMod.sol" as DiamondMod;
 
-
 /* Strategy 1: Diamond using single big DiamondCut event */
 contract SingleEventDiamond {
     event DiamondCut(DiamondMod.FacetCut[] _diamondCut);


### PR DESCRIPTION
The gas benchmarks were run for these scenarios:

- Adding 10 facets, with each facet having 8 selectors.
- Adding 50 facets, with each facet having 8 selectors.
- Adding 100 facets, with each facet having 8 selectors.

Using three event stratergies:
1.) Single Event for whole operation:
```solidity
event DiamondCut(FacetCut[] _diamondCut);
```
2.) 1 event per facet( in our case => 10,50,100)
```solidity
event AddFacet(address indexed facetAddress, bytes4[] functionSelectors);
```

3.)1 event per function( in our case => 80, 400, 800)
```solidity
event AddFunction(bytes4 indexed _selector, address indexed _facetAddress);
```

Result are as follows:
<img width="1210" height="764" alt="image" src="https://github.com/user-attachments/assets/f1aa2e88-69fd-4ca3-bb9b-be0e50cd6da3" />

## Analysis:
Facet Event is the cheapest and scales with the increase of facets.
Percentages are with comparison with facet event.

| Scenario                    | Single Event | Facet Event | Function Event | 
|-----------------------------|--------------|-------------|----------------|
| 10 facets (80 selectors)    | 2,295,156 ( +0.03 %)  | 2,294,394  | 2,372,012  (+3.38%)    | 
| 50 facets (400 selectors)   | 11,021,817  (+0.0258%) | 11,018,975 | 11,407,269   (+3.52%)  | 
| 100 facets (800 selectors)  | 21,968,096  (+0.0752%) | 21,951,595 | 22,728,211   (+3.54%)  | 

Closes the issue #245 



