### PR TITLE
chore: add exportSelectors in RoyaltyFacet

### DIFF
--- a/.changeset/modern-baboons-care.md
+++ b/.changeset/modern-baboons-care.md
@@ -1,0 +1,5 @@
+---
+"@perfect-abstractions/compose": patch
+---
+
+Add exportSelectors() to RoyaltyFacet.

--- a/.changeset/tame-ties-thank.md
+++ b/.changeset/tame-ties-thank.md
@@ -1,0 +1,5 @@
+---
+"@perfect-abstractions/compose": patch
+---
+
+Add IERC1155Metadata_URI

--- a/src/interfaces/IERC1155.sol
+++ b/src/interfaces/IERC1155.sol
@@ -156,11 +156,4 @@ interface IERC1155 {
         uint256[] calldata _values,
         bytes calldata _data
     ) external;
-
-    /**
-     * @notice Returns the URI for token type `id`.
-     * @param _id The token type to query.
-     * @return The URI for the token type.
-     */
-    function uri(uint256 _id) external view returns (string memory);
 }

--- a/src/interfaces/IERC1155Metadata_URI.sol
+++ b/src/interfaces/IERC1155Metadata_URI.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.30;
+
+/* Compose
+ * https://compose.diamonds
+ */
+
+/**
+ * @title ERC-1155 Multi Token Standard, optional metadata URI extension.
+ * @dev  See https://eips.ethereum.org/EIPS/eip-1155
+ *  Note: The ERC-165 identifier for this interface is 0x0e89341c.
+ */
+interface IERC1155Metadata_URI {
+    /**
+     * @notice Returns the URI for token type `id`.
+     * @param _id The token type to query.
+     * @return The URI for the token type.
+     */
+    function uri(uint256 _id) external view returns (string memory);
+}

--- a/src/token/Royalty/RoyaltyFacet.sol
+++ b/src/token/Royalty/RoyaltyFacet.sol
@@ -80,4 +80,13 @@ contract RoyaltyFacet {
         receiver = royalty.receiver;
         royaltyAmount = (_salePrice * royalty.royaltyFraction) / FEE_DENOMINATOR;
     }
+
+    /**
+     * @notice Exports the function selectors of the RoyaltyFacet.
+     * @dev Used as the selector discovery mechanism for diamonds.
+     * @return selectors The exported function selectors of the RoyaltyFacet.
+     */
+    function exportSelectors() external pure returns (bytes memory selectors) {
+        return bytes.concat(this.royaltyInfo.selector);
+    }
 }


### PR DESCRIPTION
## Summary
Add `exportSelectors()` to `RoyaltyFacet`.  
Add IERC1155Metadata_URI.  
Remove uri from IERC1155.  