### PR TITLE
fix: build cli before publish

### DIFF
--- a/.changeset/dry-papers-dress.md
+++ b/.changeset/dry-papers-dress.md
@@ -1,0 +1,5 @@
+---
+"@perfect-abstractions/compose-cli": patch
+---
+
+Build the CLI before publishing so the npm package includes dist output.

--- a/.github/publish-packages.json
+++ b/.github/publish-packages.json
@@ -16,7 +16,7 @@
       "versionFile": "cli/package.json",
       "tagPrefix": "compose-cli",
       "needsFoundry": false,
-      "check": "npm run cli@check && npm run cli@pack:check",
+      "check": "npm run cli@build && npm run cli@check && npm run cli@pack:check",
       "releaseNotesPaths": ["cli"],
       "releaseNotesMode": "pr"
     }


### PR DESCRIPTION
## Summary
Build the CLI before publishing so the npm package includes dist output.

## Changes Made
- Build the CLI during the publish workflow before packing/publishing.
- Ensure the published `@perfect-abstractions/compose-cli` package includes the generated `dist/` output required by `bin/compose.js`.
- Add a patch changeset for the CLI package release.

## Checklist

Before submitting this PR, please ensure:

- [ ] **Code follows the Solidity feature ban** - No inheritance, constructors, modifiers, public/private variables, external library functions, `using for` directives, or `selfdestruct`

- [ ] **Code follows Design Principles** - Readable, uses diamond storage, favors composition over inheritance

- [ ] **Code matches the codebase style** - Consistent formatting, documentation, and patterns (e.g. ERC20Facet.sol)

- [ ] **Code is formatted with `forge fmt`**

- [ ] **Existing tests pass** - Run tests to be sure existing tests pass.

- [ ] **New tests are optional** - If you don't provide tests for new functionality or changes then please [create a new issue](https://github.com/Perfect-Abstractions/Compose/issues/new/choose) so this can be assigned to someone.

- [ ] **All tests pass** - Run `forge test` and ensure everything works

- [ ] **Documentation updated** - If applicable, update relevant documentation

- [ ] **Changesets** — If this PR changes publishable packages (`src/`, `cli/`), [changeset-bot](https://github.com/apps/changeset-bot) will comment if a release note might be needed. You can add one when convenient or defer to maintainers.

Make sure to follow the [contributing](https://compose.diamonds/docs/contribution/how-to-contribute) guidelines.


