### PR TITLE
fix(cli): update Compose dependency to 0.0.6

### DIFF
--- a/.changeset/calm-tools-sync.md
+++ b/.changeset/calm-tools-sync.md
@@ -1,0 +1,5 @@
+---
+"@perfect-abstractions/compose-cli": patch
+---
+
+Update the Compose CLI to use `@perfect-abstractions/compose` 0.0.6.

--- a/cli/package.json
+++ b/cli/package.json
@@ -34,7 +34,7 @@
     "@inquirer/core": "11.2.1",
     "@inquirer/input": "5.1.2",
     "@inquirer/select": "5.2.1",
-    "@perfect-abstractions/compose": "0.0.5",
+    "@perfect-abstractions/compose": "0.0.6",
     "commander": "^13.1.0",
     "dotenv": "^16.4.7",
     "fs-extra": "^11.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@inquirer/core": "11.2.1",
         "@inquirer/input": "5.1.2",
         "@inquirer/select": "5.2.1",
-        "@perfect-abstractions/compose": "0.0.5",
+        "@perfect-abstractions/compose": "0.0.6",
         "commander": "^13.1.0",
         "dotenv": "^16.4.7",
         "fs-extra": "^11.3.3",
@@ -73,12 +73,6 @@
           "optional": true
         }
       }
-    },
-    "cli/node_modules/@perfect-abstractions/compose": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@perfect-abstractions/compose/-/compose-0.0.5.tgz",
-      "integrity": "sha512-xlPwmdO5mqEXDx4Hi/qF4R3N2wn4WuWPxvmf2ItYLzjo1hpRi8BtnvlmGoQc2iqSRlhNamv/R+g9azLlVrOyRw==",
-      "license": "MIT"
     },
     "cli/node_modules/@types/node": {
       "version": "22.19.13",


### PR DESCRIPTION
## Summary

Update the Compose CLI to use the latest published Compose library version.

## Changes Made

- Updated @perfect-abstractions/compose from 0.0.5 to 0.0.6.

- Synchronized the workspace lockfile.

## Checklist

Before submitting this PR, please ensure:

- [ ] **Code follows the Solidity feature ban** - No inheritance, constructors, modifiers, public/private variables, external library functions, `using for` directives, or `selfdestruct`

- [ ] **Code follows Design Principles** - Readable, uses diamond storage, favors composition over inheritance

- [ ] **Code matches the codebase style** - Consistent formatting, documentation, and patterns (e.g. ERC20Facet.sol)

- [ ] **Code is formatted with `forge fmt`**

- [ ] **Existing tests pass** - Run tests to be sure existing tests pass.

- [ ] **New tests are optional** - If you don't provide tests for new functionality or changes then please [create a new issue](https://github.com/Perfect-Abstractions/Compose/issues/new/choose) so this can be assigned to someone.

- [ ] **All tests pass** - Run `forge test` and ensure everything works

- [ ] **Documentation updated** - If applicable, update relevant documentation

- [ ] **Changesets** — If this PR changes publishable packages (`src/`, `cli/`), [changeset-bot](https://github.com/apps/changeset-bot) will comment if a release note might be needed. You can add one when convenient or defer to maintainers.

Make sure to follow the [contributing](https://compose.diamonds/docs/contribution/how-to-contribute) guidelines.

## Additional Notes
<!-- Any additional information, concerns, or questions for reviewers -->
